### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ## Unreleased
 
+## [[v0.7.0]](https://github.com/springload/draftail/releases/tag/v0.7.0)
+
+### Added
+
+- Make the editor toolbar sticky (requires a polyfill, documented in README).
+- Add support for `placeholder` attribute.
+
+### Changed
+
+- Improve "active block" rendering and disabled state.
+
+### Fixed
+
+- Fix missing vertical spacing between button rows.
+- Fix missing pointer cursor on tooltip button.
+
+### Removed
+
+- Remove `Element.closest` polyfill from main lib.
+
 ## [[v0.6.0]](https://github.com/springload/draftail/releases/tag/v0.6.0)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draftail",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "📝🍸 A batteries-excluded rich text editor based on Draft.js",
   "author": "Springload",
   "license": "MIT",


### PR DESCRIPTION
- Make the editor toolbar sticky (requires a polyfill, documented in README).
- Add support for `placeholder` attribute.
- Improve "active block" rendering and disabled state.
- Fix missing vertical spacing between button rows.
- Fix missing pointer cursor on tooltip button.
- Remove `Element.closest` polyfill from main lib.