### PR TITLE
Add name attribute to button elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ## Unreleased
 
+### Added
+
+- Add `name` attribute to button elements to facilitate targeting  in browser automation tests.
+
 ## [[v0.7.3]](https://github.com/springload/draftail/releases/tag/v0.7.3)
+
+### Added
 
 - Expose reusable Portal component as part of the API.
 

--- a/lib/components/Button.js
+++ b/lib/components/Button.js
@@ -9,8 +9,9 @@ const onMouseDown = (onClick, e) => {
     onClick();
 };
 
-const Button = ({ active, label, title, icon, onClick }) => (
+const Button = ({ name, active, label, title, icon, onClick }) => (
     <button
+        name={name}
         className={`RichEditor-styleButton${active ? ' RichEditor-activeButton' : ''}`}
         type="button"
         title={title}
@@ -24,6 +25,7 @@ const Button = ({ active, label, title, icon, onClick }) => (
 );
 
 Button.propTypes = {
+    name: PropTypes.string,
     active: PropTypes.bool,
     label: PropTypes.string,
     title: PropTypes.string,
@@ -32,6 +34,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
+    name: null,
     active: false,
     label: null,
     title: null,

--- a/lib/components/Button.test.js
+++ b/lib/components/Button.test.js
@@ -11,6 +11,10 @@ describe('Button', () => {
         expect(shallow(<Button />)).toMatchSnapshot();
     });
 
+    it('#name', () => {
+        expect(shallow(<Button name="TEST" />)).toMatchSnapshot();
+    });
+
     it('#label', () => {
         expect(shallow(<Button label="Test label" />)).toMatchSnapshot();
     });

--- a/lib/components/Toolbar.js
+++ b/lib/components/Toolbar.js
@@ -5,7 +5,7 @@ import DraftUtils from '../api/DraftUtils';
 
 import Button from '../components/Button';
 
-import { BR_TYPE } from '../api/constants';
+import { BR_TYPE, ENTITY_TYPE } from '../api/constants';
 import behavior from '../api/behavior';
 
 const Toolbar = ({
@@ -25,6 +25,7 @@ const Toolbar = ({
         {blockTypes.map(block => (
             <Button
                 key={block.type}
+                name={block.type}
                 active={DraftUtils.isSelectedBlockType(editorState, block.type)}
                 label={block.label}
                 title={behavior.getKeyboardShortcut(block.type)}
@@ -36,6 +37,7 @@ const Toolbar = ({
         {inlineStyles.map(style => (
             <Button
                 key={style.type}
+                name={style.type}
                 active={DraftUtils.hasCurrentInlineStyle(editorState, style.type)}
                 label={style.label}
                 title={behavior.getKeyboardShortcut(style.type)}
@@ -46,6 +48,7 @@ const Toolbar = ({
 
         {enableHorizontalRule ? (
             <Button
+                name={ENTITY_TYPE.HORIZONTAL_RULE}
                 onClick={addHR}
                 label="HR"
             />
@@ -53,6 +56,7 @@ const Toolbar = ({
 
         {enableLineBreak ? (
             <Button
+                name={BR_TYPE}
                 onClick={addBR}
                 label="BR"
                 title={behavior.getKeyboardShortcut(BR_TYPE)}
@@ -62,6 +66,7 @@ const Toolbar = ({
         {entityTypes.map(entity => (
             <Button
                 key={entity.type}
+                name={entity.type}
                 onClick={onRequestDialog.bind(null, entity.type)}
                 label={entity.label}
                 title={behavior.getKeyboardShortcut(entity.type)}

--- a/lib/components/__snapshots__/Button.test.js.snap
+++ b/lib/components/__snapshots__/Button.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Button #active 1`] = `
 <button
   className="RichEditor-styleButton RichEditor-activeButton"
+  name={null}
   onMouseDown={[Function]}
   title={null}
   type="button"
@@ -12,6 +13,7 @@ exports[`Button #active 1`] = `
 exports[`Button #icon 1`] = `
 <button
   className="RichEditor-styleButton"
+  name={null}
   onMouseDown={[Function]}
   title={null}
   type="button"
@@ -27,6 +29,7 @@ exports[`Button #icon 1`] = `
 exports[`Button #label 1`] = `
 <button
   className="RichEditor-styleButton"
+  name={null}
   onMouseDown={[Function]}
   title={null}
   type="button"
@@ -35,9 +38,20 @@ exports[`Button #label 1`] = `
 </button>
 `;
 
+exports[`Button #name 1`] = `
+<button
+  className="RichEditor-styleButton"
+  name="TEST"
+  onMouseDown={[Function]}
+  title={null}
+  type="button"
+/>
+`;
+
 exports[`Button empty 1`] = `
 <button
   className="RichEditor-styleButton"
+  name={null}
   onMouseDown={[Function]}
   title={null}
   type="button"

--- a/lib/components/__snapshots__/Toolbar.test.js.snap
+++ b/lib/components/__snapshots__/Toolbar.test.js.snap
@@ -9,6 +9,7 @@ exports[`Toolbar #blockTypes 1`] = `
     active={false}
     icon={null}
     label="Test 1"
+    name="TEST_1"
     onClick={[Function]}
     title="No keyboard shortcut"
   />
@@ -16,6 +17,7 @@ exports[`Toolbar #blockTypes 1`] = `
     active={false}
     icon="icon-test-2"
     label="Test 2"
+    name="TEST_2"
     onClick={[Function]}
     title="No keyboard shortcut"
   />
@@ -23,6 +25,7 @@ exports[`Toolbar #blockTypes 1`] = `
     active={false}
     icon="icon-test-3"
     label="Test 3"
+    name="TEST_3"
     onClick={[Function]}
     title="No keyboard shortcut"
   />
@@ -38,6 +41,7 @@ exports[`Toolbar #enableHorizontalRule 1`] = `
     active={false}
     icon={null}
     label="HR"
+    name="HORIZONTAL_RULE"
     onClick={[Function]}
     title={null}
   />
@@ -53,6 +57,7 @@ exports[`Toolbar #enableLineBreak 1`] = `
     active={false}
     icon={null}
     label="BR"
+    name="BR"
     onClick={[Function]}
     title="shift + enter"
   />
@@ -68,6 +73,7 @@ exports[`Toolbar #entityTypes 1`] = `
     active={false}
     icon={null}
     label="Test 1"
+    name="TEST_1"
     onClick={[Function]}
     title="No keyboard shortcut"
   />
@@ -75,6 +81,7 @@ exports[`Toolbar #entityTypes 1`] = `
     active={false}
     icon="icon-test-2"
     label="Test 2"
+    name="TEST_2"
     onClick={[Function]}
     title="No keyboard shortcut"
   />
@@ -82,6 +89,7 @@ exports[`Toolbar #entityTypes 1`] = `
     active={false}
     icon="icon-test-3"
     label="Test 3"
+    name="TEST_3"
     onClick={[Function]}
     title="No keyboard shortcut"
   />
@@ -97,6 +105,7 @@ exports[`Toolbar #inlineStyles 1`] = `
     active={false}
     icon={null}
     label="Test 1"
+    name="TEST_1"
     onClick={[Function]}
     title="No keyboard shortcut"
   />
@@ -104,6 +113,7 @@ exports[`Toolbar #inlineStyles 1`] = `
     active={false}
     icon="icon-test-2"
     label="Test 2"
+    name="TEST_2"
     onClick={[Function]}
     title="No keyboard shortcut"
   />
@@ -111,6 +121,7 @@ exports[`Toolbar #inlineStyles 1`] = `
     active={false}
     icon="icon-test-3"
     label="Test 3"
+    name="TEST_3"
     onClick={[Function]}
     title="No keyboard shortcut"
   />


### PR DESCRIPTION
Facilitates targeting in browser automation tests that want to script the actions of the editor. cc @sofispials