### PR TITLE
Add more correct behavior in example sources for collapsed selections.

### DIFF
--- a/examples/custom.js
+++ b/examples/custom.js
@@ -11,7 +11,7 @@ const rawContentState = {
         {
             key: 'c1gc9',
             text: 'You can also implement custom block types as required.',
-            type: 'terms-and-conditions',
+            type: 'tiny-text',
             depth: 0,
             inlineStyleRanges: [],
             entityRanges: [],

--- a/examples/index.html
+++ b/examples/index.html
@@ -57,7 +57,7 @@
                         </ul>
                         <h4>Custom block types</h4>
                         <p>New block types can be created by giving them a unique type, a label and an icon (for the toolbar), and element and className attributes:</p>
-                        <pre>{ label: 'T&amp;C', type: 'terms', element: 'div', className: 'terms' },</pre>
+                        <pre>{ label: 'Tiny', type: 'tiny-text', element: 'div', className: 'u-tinytext' },</pre>
                         <h4>Custom inline styles</h4>
                         <p>TODO</p>
                         <h4>Custom entity types</h4>

--- a/examples/sources/DocumentSource.js
+++ b/examples/sources/DocumentSource.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { RichUtils } from 'draft-js';
+import { DraftUtils } from '../../lib';
 
 class DocumentSource extends React.Component {
     componentDidMount() {
@@ -9,28 +10,43 @@ class DocumentSource extends React.Component {
             'Document URL',
             entity ? entity.getData().url : '',
         );
+        let nextState = editorState;
 
         if (url) {
-            const contentState = editorState.getCurrentContent();
-            const contentStateWithEntity = contentState.createEntity(
-                options.type,
-                'MUTABLE',
-                {
-                    url: url,
-                    title: 'Kritik der reinen Vernunft',
-                },
-            );
-            const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
-            const nextState = RichUtils.toggleLink(
-                editorState,
-                editorState.getSelection(),
-                entityKey,
-            );
+            const selection = editorState.getSelection();
+            const entityData = {
+                url: url,
+                title: 'Kritik der reinen Vernunft',
+            };
 
-            onUpdate(nextState);
-        } else {
-            onUpdate(editorState);
+            const hasText = !selection.isCollapsed();
+
+            if (hasText) {
+                const contentState = editorState.getCurrentContent();
+                const contentStateWithEntity = contentState.createEntity(
+                    options.type,
+                    'MUTABLE',
+                    entityData,
+                );
+
+                const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+                nextState = RichUtils.toggleLink(
+                    editorState,
+                    selection,
+                    entityKey,
+                );
+            } else {
+                nextState = DraftUtils.createEntity(
+                    editorState,
+                    options.type,
+                    entityData,
+                    url,
+                    'MUTABLE',
+                );
+            }
         }
+
+        onUpdate(nextState);
     }
 
     render() {

--- a/examples/sources/LinkSource.js
+++ b/examples/sources/LinkSource.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { RichUtils } from 'draft-js';
+import { DraftUtils } from '../../lib';
 
 class LinkSource extends React.Component {
     componentDidMount() {
@@ -9,27 +10,42 @@ class LinkSource extends React.Component {
             'Link URL',
             entity ? entity.getData().url : '',
         );
+        let nextState = editorState;
 
         if (url) {
-            const contentState = editorState.getCurrentContent();
-            const contentStateWithEntity = contentState.createEntity(
-                options.type,
-                'MUTABLE',
-                {
-                    url: url,
-                },
-            );
-            const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
-            const nextState = RichUtils.toggleLink(
-                editorState,
-                editorState.getSelection(),
-                entityKey,
-            );
+            const selection = editorState.getSelection();
+            const entityData = {
+                url: url,
+            };
 
-            onUpdate(nextState);
-        } else {
-            onUpdate(editorState);
+            const hasText = !selection.isCollapsed();
+
+            if (hasText) {
+                const contentState = editorState.getCurrentContent();
+                const contentStateWithEntity = contentState.createEntity(
+                    options.type,
+                    'MUTABLE',
+                    entityData,
+                );
+
+                const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+                nextState = RichUtils.toggleLink(
+                    editorState,
+                    selection,
+                    entityKey,
+                );
+            } else {
+                nextState = DraftUtils.createEntity(
+                    editorState,
+                    options.type,
+                    entityData,
+                    url,
+                    'MUTABLE',
+                );
+            }
         }
+
+        onUpdate(nextState);
     }
 
     render() {


### PR DESCRIPTION
Fixes #85. This is technically userland territory, but the "Source" API is low-level enough that proper use of it is crucial to Draftail's behaviour. Plus, the issue is in the example source implementations that are in this repo.

Here is what the new behaviour looks like, inserting text if there is no selection:

![draftail-85](https://user-images.githubusercontent.com/877585/29661784-be8c9ac6-88cd-11e7-94fb-6ab6b7e91619.gif)

I also fixed remaining references to the now removed T&C example in this same PR.