### PR TITLE
Remove image, embed, document, and link entities on paste if not enabled

### DIFF
--- a/examples/test.js
+++ b/examples/test.js
@@ -144,6 +144,8 @@ const editors = (
             enableHorizontalRule={true}
             enableLineBreak={true}
             stripPastedStyles={false}
+            /*
+            TODO: uncomment when done testing pasting invalid entities
             entityTypes={[
                 {
                     type: ENTITY_TYPE.IMAGE,
@@ -160,6 +162,7 @@ const editors = (
                     decorator: Link,
                 },
             ]}
+            */
             blockTypes={[
                 {
                     label: 'H4',

--- a/lib/api/DraftUtils.js
+++ b/lib/api/DraftUtils.js
@@ -196,8 +196,8 @@ export default {
         const shouldNormaliseType = block => {
             const type = block.getType();
             return (
-                // TODO Should handle atomic blocks separately.
                 type !== BLOCK_TYPE.UNSTYLED &&
+                type !== BLOCK_TYPE.ATOMIC &&
                 enabledBlockTypes.indexOf(type) === -1
             );
         };
@@ -214,6 +214,69 @@ export default {
         return EditorState.set(editorState, {
             currentContent: contentState,
         });
+    },
+
+    /**
+     * Reset all entity types (images, links, documents, embeds) that are unavailable.
+     * Meant to be used after a paste of unconstrained content.
+     */
+    normalizeEntityType(editorState, enabledTypes) {
+        let contentState = editorState.getCurrentContent();
+        let blockMap = contentState.getBlockMap();
+
+        const isValidEntity = char => {
+            let isValid = true;
+            const entityKey = char.getEntity();
+            if (entityKey !== null) {
+                const entityType = contentState.getEntity(entityKey).getType();
+                if (enabledTypes.indexOf(entityType) === -1) {
+                    isValid = false;
+                }
+            }
+            return isValid;
+        };
+
+        const isValidAtomicBlock = block => {
+            // Remove invalid image and document blocks if not enabled
+            let isValidBlock = true;
+            block.findEntityRanges(
+                char => {
+                    isValidBlock = isValidEntity(char);
+                },
+                () => {},
+            );
+            return isValidBlock;
+        };
+
+        const isValidInline = block => {
+            let altered = false;
+
+            const chars = block.getCharacterList().filter(char => {
+                let newChar = char;
+                if (!isValidEntity(char)) {
+                    altered = true;
+                    newChar = CharacterMetadata.applyEntity(newChar, null);
+                }
+                return newChar;
+            });
+
+            return altered ? block.set('characterList', chars) : block;
+        };
+
+        blockMap = blockMap.filter(isValidAtomicBlock);
+        const blocks = blockMap.map(isValidInline);
+        blockMap = blockMap.merge(blocks);
+        contentState = contentState.merge({ blockMap });
+
+        let newEditorState = EditorState.set(editorState, {
+            currentContent: contentState,
+        });
+
+        // TODO: instead of moving selection and focus to the end, move it to previous block,
+        // if the last block in the paste selection was removed.
+        newEditorState = EditorState.moveSelectionToEnd(newEditorState);
+        newEditorState = EditorState.moveFocusToEnd(newEditorState);
+        return newEditorState;
     },
 
     /**

--- a/lib/api/behavior.js
+++ b/lib/api/behavior.js
@@ -260,11 +260,11 @@ export default {
         enableLineBreak,
         blockTypes = [],
         inlineStyles = [],
-        // TODO Implement.
-        // entityTypes = [],
+        entityTypes = [],
     ) {
         let nextEditorState = editorState;
         const enabledBlockTypes = blockTypes.map(type => type.type);
+        const enabledEntityTypes = entityTypes.map(type => type.type);
         const enabledInlineStyles = inlineStyles.map(type => type.type);
 
         nextEditorState = DraftUtils.normaliseBlockDepth(
@@ -275,6 +275,11 @@ export default {
         nextEditorState = DraftUtils.normaliseBlockType(
             nextEditorState,
             enabledBlockTypes,
+        );
+
+        nextEditorState = DraftUtils.normalizeEntityType(
+            nextEditorState,
+            enabledEntityTypes,
         );
 
         // TODO Re-test what happens when pasting a styled element, eg. h2 with bold, or blockquote with italic.


### PR DESCRIPTION
**Description**
This PR includes a call to an additional function `normalizeEntityType` which aims to remove non-enabled entities from the Draftail editor.

**Current State**
Currently, pasting from Word or HTML _does_ strip out invalid inline entities and removes blocks that have invalid entities entirely. Similarly, pasting from another Draftail editor strips these out.

**TODO**
- If you paste into an existing block, the entity _text_ for images will not be removed (but the `entityMap` and `entityRanges` will be).
- When a block is removed, it is still selected. This is currently solved by moving the selection to the end of the content (`moveSelectionToEnd`) but this is incorrect. If there are additional blocks _after_ the paste, the selection will still be moved to the end which is not desired behavior.
- `<hr />` are not removed.
- Not sure if `findEntityRanges` is the best solution.
- Currently no validation that blocks removed have the `ATOMIC` type because the `TYPE` of the image block is `unstyled` when it's pasted (unless it's from another draftail editor?)
- Needs tests

I can potentially work more on this. Please feel free to add comments/suggestions.