### PR TITLE
Prevent text inserted after entities from continuing the entity. Fix #86

### DIFF
--- a/lib/api/DraftUtils.js
+++ b/lib/api/DraftUtils.js
@@ -11,6 +11,10 @@ import { BLOCK_TYPE, ENTITY_TYPE } from '../api/constants';
 
 /**
  * Wrapper around draftjs-utils, with our custom functions.
+ * https://github.com/jpuri/draftjs-utils
+ *
+ * DraftUtils functions are utility helpers useful in isolation, specific to the Draft.js API,
+ * without ties to Draftail's specific behavior or other APIs.
  */
 export default {
     getSelectionEntity: DraftUtils.getSelectionEntity.bind(DraftUtils),
@@ -91,6 +95,7 @@ export default {
                 contentState,
                 selection,
                 entityText,
+                // TODO Is this meant to be removing styles?
                 null,
                 entityKey,
             );
@@ -99,6 +104,7 @@ export default {
                 contentState,
                 selection,
                 entityText,
+                // TODO Is this meant to be removing styles?
                 null,
                 entityKey,
             );

--- a/lib/api/DraftUtils.js
+++ b/lib/api/DraftUtils.js
@@ -168,6 +168,28 @@ export default {
         });
     },
 
+    hasNoSelectionStartEntity(selection, block) {
+        const startOffset = selection.getStartOffset();
+
+        return block.getEntityAt(startOffset) === null;
+    },
+
+    insertTextWithoutEntity(editorState, text) {
+        const currentContent = editorState.getCurrentContent();
+        const selection = editorState.getSelection();
+        const style = editorState.getCurrentInlineStyle();
+
+        const newContent = Modifier.insertText(
+            currentContent,
+            selection,
+            text,
+            style,
+            null,
+        );
+
+        return EditorState.push(editorState, newContent, 'insert-characters');
+    },
+
     /**
      * Reset the depth of all the content to be at most maxListNesting.
      * Meant to be used after a paste of non-constrained list items.

--- a/lib/api/DraftUtils.test.js
+++ b/lib/api/DraftUtils.test.js
@@ -167,6 +167,85 @@ describe('DraftUtils', () => {
         });
     });
 
+    describe('#hasNoSelectionStartEntity', () => {
+        it('caret within entity text', () => {
+            const editorState = EditorState.createWithContent(
+                ContentState.createFromBlockArray(
+                    convertFromHTML(`<h1>Test</h1>`),
+                ),
+            );
+            const contentStateWithEntity = editorState
+                .getCurrentContent()
+                .createEntity('LINK', 'MUTABLE', { url: 'www.testing.com' });
+            const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+            const newEditorState = RichUtils.toggleLink(
+                editorState,
+                editorState.getSelection().merge({
+                    anchorOffset: 0,
+                    focusOffset: 4,
+                }),
+                entityKey,
+            );
+
+            const selection = newEditorState.getSelection().merge({
+                anchorOffset: 2,
+                focusOffset: 0,
+            });
+            expect(
+                DraftUtils.hasNoSelectionStartEntity(
+                    selection,
+                    newEditorState.getCurrentContent().getFirstBlock(),
+                ),
+            ).toBe(false);
+        });
+
+        it('caret at the end of the entity text', () => {
+            const editorState = EditorState.createWithContent(
+                ContentState.createFromBlockArray(
+                    convertFromHTML(`<h1>Test</h1>`),
+                ),
+            );
+            const contentStateWithEntity = editorState
+                .getCurrentContent()
+                .createEntity('LINK', 'MUTABLE', { url: 'www.testing.com' });
+            const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+            const newEditorState = RichUtils.toggleLink(
+                editorState,
+                editorState.getSelection().merge({
+                    anchorOffset: 0,
+                    focusOffset: 4,
+                }),
+                entityKey,
+            );
+
+            const selection = newEditorState.getSelection().merge({
+                anchorOffset: 4,
+                focusOffset: 0,
+            });
+            expect(
+                DraftUtils.hasNoSelectionStartEntity(
+                    selection,
+                    newEditorState.getCurrentContent().getFirstBlock(),
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe('#insertTextWithoutEntity', () => {
+        it('works', () => {
+            const editorState = DraftUtils.insertTextWithoutEntity(
+                EditorState.createWithContent(
+                    ContentState.createFromBlockArray(
+                        convertFromHTML(`<h1>Test</h1>`),
+                    ),
+                ),
+                '!',
+            );
+            const block = editorState.getCurrentContent().getFirstBlock();
+            expect(block.getText()).toEqual('!Test');
+        });
+    });
+
     describe('#shouldHidePlaceholder', () => {
         it('is empty', () => {
             expect(

--- a/lib/api/behavior.js
+++ b/lib/api/behavior.js
@@ -24,7 +24,7 @@ const { hasCommandModifier, isOptionKeyCommand } = KeyBindingUtil;
 const isMacOS = isOptionKeyCommand({ altKey: 'test' }) === 'test';
 
 /**
- * Behavioral methods for the editor, generated from its configuration.
+ * Methods defining the behavior of the editor, depending on its configuration.
  */
 export default {
     /**

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -368,9 +368,21 @@ class DraftailEditor extends Component {
         const { blockTypes } = this.props;
         const { editorState } = this.state;
         const selection = editorState.getSelection();
-        const block = DraftUtils.getSelectedBlock(editorState);
 
         if (selection.isCollapsed()) {
+            const block = DraftUtils.getSelectedBlock(editorState);
+
+            // Necessary to prevent entities from continuing when inserting text afterwards.
+            // See https://github.com/springload/draftail/issues/86.
+            // See https://github.com/facebook/draft-js/issues/430.
+            if (DraftUtils.hasNoSelectionStartEntity(selection, block)) {
+                this.onChange(
+                    DraftUtils.insertTextWithoutEntity(editorState, char),
+                );
+
+                return HANDLED;
+            }
+
             const newBlockType = behavior.handleBeforeInputBlockType(
                 char,
                 block,


### PR DESCRIPTION
This is https://github.com/facebook/draft-js/issues/430#issuecomment-269815367, as two DraftUtils functions. New behavior:

![entity-continue](https://user-images.githubusercontent.com/877585/32893268-7c364694-cae1-11e7-9bda-a7edfbe2abe5.gif)
