### PR TITLE
Add workaround for RichUtils image delete blind spot

### DIFF
--- a/lib/api/DraftUtils.js
+++ b/lib/api/DraftUtils.js
@@ -218,6 +218,34 @@ export default {
     },
 
     /**
+     * Handles pressing delete within an atomic block. This can happen when selection is placed on an image.
+     * Ideally this should be handled by the built-in RichUtils, but it's not.
+     * See https://github.com/wagtail/wagtail/issues/4370.
+     */
+    handleDeleteAtomic(editorState) {
+        const selection = editorState.getSelection();
+        const content = editorState.getCurrentContent();
+        const key = selection.getAnchorKey();
+        const offset = selection.getAnchorOffset();
+        const block = content.getBlockForKey(key);
+
+        // Problematic selection. Pressing delete here would remove the entity, but not the block.
+        if (
+            selection.isCollapsed() &&
+            block.getType() === BLOCK_TYPE.ATOMIC &&
+            offset === 0
+        ) {
+            return this.removeBlockEntity(
+                editorState,
+                block.getEntityAt(0),
+                key,
+            );
+        }
+
+        return false;
+    },
+
+    /**
      * Get an entity decorator strategy based on the given entity type.
      * This strategy will find all entities of the given type.
      */

--- a/lib/api/DraftUtils.test.js
+++ b/lib/api/DraftUtils.test.js
@@ -407,6 +407,129 @@ describe('DraftUtils', () => {
         });
     });
 
+    describe('#handleDeleteAtomic', () => {
+        it('works', () => {
+            const contentState = convertFromRaw({
+                entityMap: {
+                    '1': {
+                        type: 'IMAGE',
+                        data: {},
+                    },
+                },
+                blocks: [
+                    {
+                        key: 'a',
+                        text: ' ',
+                        type: 'atomic',
+                        entityRanges: [{ offset: 0, length: 1, key: 1 }],
+                    },
+                ],
+            });
+            let editorState = EditorState.createWithContent(contentState);
+            editorState = DraftUtils.handleDeleteAtomic(editorState);
+            expect(
+                editorState
+                    .getCurrentContent()
+                    .getBlockMap()
+                    .map(b => b.toJS())
+                    .toJS(),
+            ).toEqual({
+                a: {
+                    characterList: [],
+                    data: {},
+                    depth: 0,
+                    key: 'a',
+                    text: '',
+                    type: 'unstyled',
+                },
+            });
+        });
+
+        it('not collapsed', () => {
+            const contentState = convertFromRaw({
+                entityMap: {
+                    '1': {
+                        type: 'IMAGE',
+                        data: {},
+                    },
+                },
+                blocks: [
+                    {
+                        key: 'a',
+                        text: ' ',
+                        type: 'atomic',
+                        entityRanges: [{ offset: 0, length: 1, key: 1 }],
+                    },
+                ],
+            });
+            let editorState = EditorState.createWithContent(contentState);
+            const selection = editorState.getSelection().merge({
+                anchorKey: 'a',
+                focusKey: 'a',
+                anchorOffset: 0,
+                focusOffset: 1,
+            });
+            editorState = EditorState.forceSelection(editorState, selection);
+            expect(DraftUtils.handleDeleteAtomic(editorState)).toEqual(false);
+        });
+
+        it('not block start', () => {
+            const contentState = convertFromRaw({
+                entityMap: {
+                    '1': {
+                        type: 'IMAGE',
+                        data: {},
+                    },
+                },
+                blocks: [
+                    {
+                        key: 'a',
+                        text: ' ',
+                        type: 'atomic',
+                        entityRanges: [{ offset: 0, length: 1, key: 1 }],
+                    },
+                ],
+            });
+            let editorState = EditorState.createWithContent(contentState);
+            const selection = editorState.getSelection().merge({
+                anchorKey: 'a',
+                focusKey: 'a',
+                anchorOffset: 1,
+                focusOffset: 1,
+            });
+            editorState = EditorState.forceSelection(editorState, selection);
+            expect(DraftUtils.handleDeleteAtomic(editorState)).toEqual(false);
+        });
+
+        it('not atomic', () => {
+            const contentState = convertFromRaw({
+                entityMap: {
+                    '1': {
+                        type: 'IMAGE',
+                        data: {},
+                    },
+                },
+                blocks: [
+                    {
+                        key: 'a',
+                        text: ' ',
+                        type: 'unstyled',
+                        entityRanges: [{ offset: 0, length: 1, key: 1 }],
+                    },
+                ],
+            });
+            let editorState = EditorState.createWithContent(contentState);
+            const selection = editorState.getSelection().merge({
+                anchorKey: 'a',
+                focusKey: 'a',
+                anchorOffset: 0,
+                focusOffset: 0,
+            });
+            editorState = EditorState.forceSelection(editorState, selection);
+            expect(DraftUtils.handleDeleteAtomic(editorState)).toEqual(false);
+        });
+    });
+
     describe('#shouldHidePlaceholder', () => {
         it('is empty', () => {
             expect(

--- a/lib/api/constants.js
+++ b/lib/api/constants.js
@@ -42,6 +42,10 @@ export const INLINE_STYLE = {
     SUBSCRIPT: 'SUBSCRIPT',
 };
 
+export const BLOCK_TYPES = Object.values(BLOCK_TYPE);
+export const ENTITY_TYPES = Object.values(ENTITY_TYPE);
+export const INLINE_STYLES = Object.values(INLINE_STYLE);
+
 export const FONT_FAMILY_MONOSPACE =
     'Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif';
 

--- a/lib/api/constants.test.js
+++ b/lib/api/constants.test.js
@@ -2,6 +2,9 @@ import {
     BLOCK_TYPE,
     ENTITY_TYPE,
     INLINE_STYLE,
+    BLOCK_TYPES,
+    ENTITY_TYPES,
+    INLINE_STYLES,
     FONT_FAMILY_MONOSPACE,
     CUSTOM_STYLE_MAP,
     BR_TYPE,
@@ -21,6 +24,9 @@ describe('constants', () => {
     it('#BLOCK_TYPE', () => expect(BLOCK_TYPE).toBeDefined());
     it('#ENTITY_TYPE', () => expect(ENTITY_TYPE).toBeDefined());
     it('#INLINE_STYLE', () => expect(INLINE_STYLE).toBeDefined());
+    it('#BLOCK_TYPES', () => expect(BLOCK_TYPES).toBeDefined());
+    it('#ENTITY_TYPES', () => expect(ENTITY_TYPES).toBeDefined());
+    it('#INLINE_STYLES', () => expect(INLINE_STYLES).toBeDefined());
     it('#FONT_FAMILY_MONOSPACE', () =>
         expect(FONT_FAMILY_MONOSPACE).toBeDefined());
     it('#CUSTOM_STYLE_MAP', () => expect(CUSTOM_STYLE_MAP).toBeDefined());

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -247,6 +247,16 @@ class DraftailEditor extends Component {
             return true;
         }
 
+        // Special case – some delete commands on atomic blocks are not covered by RichUtils.
+        if (command === 'delete') {
+            const newState = DraftUtils.handleDeleteAtomic(editorState);
+
+            if (newState) {
+                this.onChange(newState);
+                return true;
+            }
+        }
+
         const newState = RichUtils.handleKeyCommand(editorState, command);
         if (newState) {
             this.onChange(newState);

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -230,28 +230,29 @@ class DraftailEditor extends Component {
         const { editorState } = this.state;
         const isKnownCommand = (commands, comm) =>
             Object.keys(commands).find(key => commands[key] === comm);
-        let newState;
-        let ret = false;
 
         if (isKnownCommand(ENTITY_TYPE, command)) {
-            ret = true;
             this.onRequestSource(command);
-        } else if (isKnownCommand(BLOCK_TYPE, command)) {
-            ret = true;
-            this.toggleBlockType(command);
-        } else if (isKnownCommand(INLINE_STYLE, command)) {
-            ret = true;
-            this.toggleInlineStyle(command);
-        } else {
-            newState = RichUtils.handleKeyCommand(editorState, command);
-
-            if (newState) {
-                ret = true;
-                this.onChange(newState);
-            }
+            return true;
         }
 
-        return ret;
+        if (isKnownCommand(BLOCK_TYPE, command)) {
+            this.toggleBlockType(command);
+            return true;
+        }
+
+        if (isKnownCommand(INLINE_STYLE, command)) {
+            this.toggleInlineStyle(command);
+            return true;
+        }
+
+        const newState = RichUtils.handleKeyCommand(editorState, command);
+        if (newState) {
+            this.onChange(newState);
+            return true;
+        }
+
+        return false;
     }
 
     handleBeforeInput(char) {

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -6,7 +6,6 @@ import { ListNestingStyles } from 'draftjs-conductor';
 import {
     ENTITY_TYPE,
     BLOCK_TYPE,
-    INLINE_STYLE,
     ENTITY_TYPES,
     BLOCK_TYPES,
     INLINE_STYLES,

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -7,6 +7,9 @@ import {
     ENTITY_TYPE,
     BLOCK_TYPE,
     INLINE_STYLE,
+    ENTITY_TYPES,
+    BLOCK_TYPES,
+    INLINE_STYLES,
     HANDLED,
     NOT_HANDLED,
     UNDO_TYPE,
@@ -228,20 +231,18 @@ class DraftailEditor extends Component {
 
     handleKeyCommand(command) {
         const { editorState } = this.state;
-        const isKnownCommand = (commands, comm) =>
-            Object.keys(commands).find(key => commands[key] === comm);
 
-        if (isKnownCommand(ENTITY_TYPE, command)) {
+        if (ENTITY_TYPES.includes(command)) {
             this.onRequestSource(command);
             return true;
         }
 
-        if (isKnownCommand(BLOCK_TYPE, command)) {
+        if (BLOCK_TYPES.includes(command)) {
             this.toggleBlockType(command);
             return true;
         }
 
-        if (isKnownCommand(INLINE_STYLE, command)) {
+        if (INLINE_STYLES.includes(command)) {
             this.toggleInlineStyle(command);
             return true;
         }

--- a/lib/components/DraftailEditor.test.js
+++ b/lib/components/DraftailEditor.test.js
@@ -439,6 +439,36 @@ describe('DraftailEditor', () => {
                     .handleKeyCommand('BOLD'),
             ).toBe(true);
         });
+
+        describe('delete', () => {
+            it('handled', () => {
+                jest
+                    .spyOn(DraftUtils, 'handleDeleteAtomic')
+                    .mockImplementation(e => e);
+
+                expect(
+                    shallow(<DraftailEditor />)
+                        .instance()
+                        .handleKeyCommand('delete'),
+                ).toBe(true);
+                expect(DraftUtils.handleDeleteAtomic).toHaveBeenCalled();
+
+                DraftUtils.handleDeleteAtomic.mockRestore();
+            });
+
+            it('not handled', () => {
+                jest.spyOn(DraftUtils, 'handleDeleteAtomic');
+
+                expect(
+                    shallow(<DraftailEditor />)
+                        .instance()
+                        .handleKeyCommand('delete'),
+                ).toBe(false);
+                expect(DraftUtils.handleDeleteAtomic).toHaveBeenCalled();
+
+                DraftUtils.handleDeleteAtomic.mockRestore();
+            });
+        });
     });
 
     describe('handleBeforeInput', () => {


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/4370.

![draftail-delete-image-fix](https://user-images.githubusercontent.com/877585/37948978-4667bf72-319b-11e8-992a-d85eee2c6110.gif)

This now replaces the block and image with an empty unstyled block.