### PR TITLE
WIP: On paste, read content from internal clipboard via paste registry

### DIFF
--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { Editor, EditorState, RichUtils } from 'draft-js';
+import { Editor, EditorState, RichUtils, Modifier } from 'draft-js';
 import { ListNestingStyles } from 'draftjs-conductor';
 
 import {
@@ -48,6 +48,7 @@ class DraftailEditor extends Component {
         this.onTab = this.onTab.bind(this);
         this.handleKeyCommand = this.handleKeyCommand.bind(this);
         this.handleBeforeInput = this.handleBeforeInput.bind(this);
+        this.handlePastedText = this.handlePastedText.bind(this);
 
         this.toggleBlockType = this.toggleBlockType.bind(this);
         this.toggleInlineStyle = this.toggleInlineStyle.bind(this);
@@ -310,6 +311,32 @@ class DraftailEditor extends Component {
         }
 
         return NOT_HANDLED;
+    }
+
+    handlePastedText(text, html, editorState) {
+        const editorKey = this.editorRef.getEditorKey();
+        const isEditor = html.includes('data-editor');
+        const htmlKey = isEditor ? /data-editor="(\w+)"/.exec(html)[1] : '';
+
+        if (!htmlKey || htmlKey === editorKey || !window.editorRefs[htmlKey]) {
+            return false;
+        }
+
+        const clipboard = window.editorRefs[htmlKey].getClipboard();
+
+        if (clipboard) {
+            const newContent = Modifier.replaceWithFragment(
+                editorState.getCurrentContent(),
+                editorState.getSelection(),
+                clipboard,
+            );
+            this.onChange(
+                EditorState.push(editorState, newContent, 'insert-fragment'),
+            );
+            return true;
+        }
+
+        return false;
     }
 
     toggleBlockType(blockType) {
@@ -588,6 +615,15 @@ class DraftailEditor extends Component {
                     customStyleMap={behavior.getCustomStyleMap(inlineStyles)}
                     ref={ref => {
                         this.editorRef = ref;
+                        if (ref) {
+                            window.editorRefs = Object.assign(
+                                {},
+                                window.editorRefs,
+                                {
+                                    [ref.getEditorKey()]: ref,
+                                },
+                            );
+                        }
                     }}
                     editorState={editorState}
                     onChange={this.onChange}
@@ -609,6 +645,7 @@ class DraftailEditor extends Component {
                     )}
                     handleKeyCommand={this.handleKeyCommand}
                     handleBeforeInput={this.handleBeforeInput}
+                    handlePastedText={this.handlePastedText}
                     onFocus={this.onFocus}
                     onBlur={this.onBlur}
                     onTab={this.onTab}


### PR DESCRIPTION
Partly addresses #147, https://github.com/facebook/draft-js/issues/787.

This is a hack – we leverage the internal Draft.js clipboard (containing a BlockMap ready to be inserted with `Modifier.insertFragment`) for pastes between different editors on the same page.

This only works for editors within a single page, and won't work either if the page is reloaded between "copy" and "paste" (because of the editor refs registry at `window.editorRefs`).

It also doesn't de-register editor refs – ideally those operations should be in the `componentDidMount` / `componentWillUnmount` hooks, rather than in the `ref` callback.

---

This is testable on http://localhost:4000/examples/, by copying the content of the "Custom formats" editor (which has a `DOCUMENT` entity, and also an `EMBED`) into the "Wagtail features" editor. This is also demonstrable with the `HORIZONTAL_RULE` in the "All" editor.