### PR TITLE
Dev tooling upgrades

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ indent_style = space
 indent_size = 4
 
 # Rules for tool configuration.
-[{package.json,*.yml, *.yaml}]
+[{package.json,*.yml,*.yaml}]
 indent_size = 2
 
 # Rules for markdown documents.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -81,4 +81,4 @@ npm publish
 * Finally, go to GitHub and create a release and a tag for the new version.
 * Done!
 
-> As a last step, you may want to go update our [Draft.js exporter demo](https://github.com/springload/draftjs_exporter_demo) to this new release to check that all is well in a fully separate project.
+> As a last step, you may want to go update the [Draftail Playground](https://github.com/thibaudcolas/draftail-playground) to this new release to check that all is well in a fully separate project.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,6 +59,8 @@ npm run test:coverage
 npm run report:coverage
 # Open the build report with:
 npm run report:build
+# Open the file size report with:
+npm run report:size
 # View other available commands with:
 npm run
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,17 +10,17 @@ Please note that this project is released with a [Contributor Code of Conduct](/
 
 The behavior of this editor is heavily inspired by prior art. If you want to discuss changing how the editor behaves, please take some time to consider how other editors operate. We specifically refer to:
 
-* [ ] [Microsoft Word](https://products.office.com/en/word)
-* [ ] [Microsoft Word Online](https://office.live.com/start/Word.aspx)
-* [ ] [Google Docs](https://docs.google.com/)
-* [ ] [Apple Pages](https://www.apple.com/lae/pages/)
-* [ ] [Dropbox Paper](https://www.dropbox.com/paper)
-* [ ] [Gmail](https://www.google.com/gmail/)
-* [ ] [TinyMCE](https://www.tinymce.com/)
-* [ ] [CKEditor](https://ckeditor.com)
-* [ ] [Quill](https://quilljs.com/)
-* [ ] [Slate](http://slatejs.org/)
-* [ ] Other [Draft.js editors](https://github.com/nikgraf/awesome-draft-js)
+*   [ ] [Microsoft Word](https://products.office.com/en/word)
+*   [ ] [Microsoft Word Online](https://office.live.com/start/Word.aspx)
+*   [ ] [Google Docs](https://docs.google.com/)
+*   [ ] [Apple Pages](https://www.apple.com/lae/pages/)
+*   [ ] [Dropbox Paper](https://www.dropbox.com/paper)
+*   [ ] [Gmail](https://www.google.com/gmail/)
+*   [ ] [TinyMCE](https://www.tinymce.com/)
+*   [ ] [CKEditor](https://ckeditor.com)
+*   [ ] [Quill](https://quilljs.com/)
+*   [ ] [Slate](http://slatejs.org/)
+*   [ ] Other [Draft.js editors](https://github.com/nikgraf/awesome-draft-js)
 
 ## Development
 
@@ -65,11 +65,11 @@ npm run
 
 ### Releases
 
-* Make a new branch for the release of the new version.
-* Update the [CHANGELOG](CHANGELOG.md).
-* Update the version number in `package.json`, following semver.
-* Make a PR and squash merge it.
-* Back on master with the PR merged, follow the instructions below.
+*   Make a new branch for the release of the new version.
+*   Update the [CHANGELOG](CHANGELOG.md).
+*   Update the version number in `package.json`, following semver.
+*   Make a PR and squash merge it.
+*   Back on master with the PR merged, follow the instructions below.
 
 ```sh
 npm run dist
@@ -78,7 +78,7 @@ irish-pub
 npm publish
 ```
 
-* Finally, go to GitHub and create a release and a tag for the new version.
-* Done!
+*   Finally, go to GitHub and create a release and a tag for the new version.
+*   Done!
 
 > As a last step, you may want to go update the [Draftail Playground](https://github.com/thibaudcolas/draftail-playground) to this new release to check that all is well in a fully separate project.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 _Before_ submitting a pull request, please make sure to:
 
-1. Create your branch from the up to date `master` branch.
-2. If you've added code, add tests!
-3. If you've changed APIs, update the documentation.
-4. Ensure that:
+1.  Create your branch from the up to date `master` branch.
+2.  If you've added code, add tests!
+3.  If you've changed APIs, update the documentation.
+4.  Ensure that:
 
-* The test suite passes, with 100% coverage (`npm run test:coverage`)
-* The linting passes (`npm run lint`).
+*   The test suite passes, with 100% coverage (`npm run test:coverage`)
+*   The linting passes (`npm run lint`).
 
 Thanks for contributing to Draftail!

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ public/*.map
 public/*.html
 public/*.js
 public/examples
+public/test-results.json
 
 # Dependency directories
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,11 @@ install:
 - npm install -g coveralls
 script:
 - npm run test:ci
-# Display image snapshot differences, if any.
-# This is cheap, will require people to copy-paste base64 strings all the time,
-# but otherwise we would have to upload those artefacts to a service like S3 or imgur, which requires infrastructure.
 - base64 < ./tests/integration/__image_snapshots__/__diff_output__/* || true
-# Move build artefacts to public folder so they are published on the demo site.
+- npm run danger
+- npm run report:size
 - mv webpack/webpack-stats.html public || true
 - mv coverage/lcov-report public || true
-- npm run report:size
 after_success:
 - cat ./coverage/lcov.info | coveralls
 branches:
@@ -24,9 +21,7 @@ branches:
 deploy:
   provider: pages
   skip_cleanup: true
-  # Only deploy the subfolder, not the whole repository.
   local_dir: public
-  # This value is stored below, encrypted with travis-encrypt.
   github_token: "$GITHUB_TOKEN"
   on:
     branch: master
@@ -37,4 +32,5 @@ notifications:
       secure: YnWcwBDnn2fXLsQ9692oC6+Ep10ZDurqnyNhwdFyAaOHAG+CynRGG3pCdRcr8kpPqicCC056xHMXWfY+K5LB4HwjOud7ztJzjTsvs+gvacNDUq9U41JHwxsMHk5Ei37OslbXMFlI4jPXB1lt32+T43nxt9FwEwDPqZDdiaJ639jElm3Dj5KoojCBLrw2Iyi0nRDod5QPviu/VMIC5A+nN7cXdxR8QTKV5M3YDVhKK7k2ofI+UwzcpfJOY7sl0kJBL+mbOLWyISrVKmYVq4THem2ipO4ImO+r0FGZUkNRH4qHsMhv7ERiGHYIcALOV7kY5sKgJk6xGTJExcV+dh5DH9xVz13lvriRLZSzTBlbQHtAFZV/qEUSAcazzhYGguFqPKglQwNPGPNGb0Jzzd7a+B88mY+sye2N14rij0B/gKRDBm95tP1WtLpSIaNjoiuKStMCoMn+V+WaAUb1H3HSd45DElvce6SHVOCvx0+ppXsET1m7u3WRIn8V+aYOliWw/cLnpUi+ad1eAW2ltxOa7ei0LqT7oxvK6ca7JZrCgAReYHApgUrMWZhLz53VpGnDuMXSgfGLiimH2OzSv2+nq2l1pjOTd3dGFsShhqa+PxKIe0U2vle8YXYPRvk3K2Twen5bcV1HkWw/jCt9X6KpuyjDbtK+twMMWMYTnpgQG3E=
 env:
   global:
-    secure: JmsnY0Q7HK15mJMOmIBvbcQngXoEwr9emssotKDo1IYctPe2k9X/0bRR1cR11aHSQh+Vf6oI0isbf4+Ic6O1tKjrF/PUeqeLR2euiAZoeUn7hlcZTgoAfQgSXhM7VAQ5uprc6kMP5ox7k1sBmLf4XnmggGvAd71OKa5ej5bddH4LTcb9VpKBKpJU9c2HmYgFlDVMHnQWxh25mWU/wqHD2gMkzz9O5vfQVYShqd2QMBeU/maowH5n5eeozYIkzOBdOtlNM60Hm0PsN4KTVj8iNax8/OnhZpArdF0QXAgSnx9dVMp6ggXlA34oHi+ASvVD+0c0S5ZD8tERw73OKeXG5IOQDVyxl5n2jbBJ2bYxtge/xHlgyNmUjmeZJVSXuUSwFSqK5BuhrRq+UP6gq8ccggwzvetg6JD2SyewAD5kmfObmF2ifJZd7jpZ+CGD9OLiXeCP501FyUIxGxJHj0vwcWUN9kJRcL/TOC4Oad6ljmH7Ygi5erZkyLK9crGyd7YwC59ZBeJ1tMtZcGi9yXL2cklDj9T3elQf5PkFqD+D+GfwpsK8oc/6kS9Qk/TxMVzPIlT1lXBQMgN/fOTWUVAs7XoXjtpcgWXuh1AwJEZHvqO2es0axRzTcSeSJuZf77v6koexTnfkWjD5HFvqAe2Mv8Glykjeyh3d8U00DT17Kvw=
+  - secure: JmsnY0Q7HK15mJMOmIBvbcQngXoEwr9emssotKDo1IYctPe2k9X/0bRR1cR11aHSQh+Vf6oI0isbf4+Ic6O1tKjrF/PUeqeLR2euiAZoeUn7hlcZTgoAfQgSXhM7VAQ5uprc6kMP5ox7k1sBmLf4XnmggGvAd71OKa5ej5bddH4LTcb9VpKBKpJU9c2HmYgFlDVMHnQWxh25mWU/wqHD2gMkzz9O5vfQVYShqd2QMBeU/maowH5n5eeozYIkzOBdOtlNM60Hm0PsN4KTVj8iNax8/OnhZpArdF0QXAgSnx9dVMp6ggXlA34oHi+ASvVD+0c0S5ZD8tERw73OKeXG5IOQDVyxl5n2jbBJ2bYxtge/xHlgyNmUjmeZJVSXuUSwFSqK5BuhrRq+UP6gq8ccggwzvetg6JD2SyewAD5kmfObmF2ifJZd7jpZ+CGD9OLiXeCP501FyUIxGxJHj0vwcWUN9kJRcL/TOC4Oad6ljmH7Ygi5erZkyLK9crGyd7YwC59ZBeJ1tMtZcGi9yXL2cklDj9T3elQf5PkFqD+D+GfwpsK8oc/6kS9Qk/TxMVzPIlT1lXBQMgN/fOTWUVAs7XoXjtpcgWXuh1AwJEZHvqO2es0axRzTcSeSJuZf77v6koexTnfkWjD5HFvqAe2Mv8Glykjeyh3d8U00DT17Kvw=
+  - secure: JPuBagp3GGwLOJ7zoRzStFC0HMGTunO9CgCzmmBiIz16Uj3L3zhL5LDDnlaQcBkgwFqMdu3+0Mm9B3XUDf0UqYoJi+ZLRkbXRmacTpWGWvPq5sByb9+oJ31CDfvbmwi8K4B4qupcKGEgNTtdVo2fjKKtemZo/ytboFkOusSySVrf2apqLHOrNYZa2UPtrCcwpZUzGXND9VDXiWsC3xqC5N680Ri9iHBta+uQ2IMnhJQkAszrhXgEbk18qzkhaPzWMT7f0ERXk+aAVhfz/e7VCG2fD14a7a96KHUe/K4Q4SVAh2caDwLydINbzfWkCcDvjcaVFVP5I+Xjsk3Kcdp/+oR2QgP1qSKpY6WD9TRKMFIaJ4oCGLX3Ka78fYD9LxgJRIk4pFt8xbgwU09rYrsO1k2WvKntz7e8vhciXbTMwyhgkeVs3Ojz8qMgAtyWXFrNmiKtIcQdXFKBE6LbKhZIUMM75h4g61bc4CLjqWP3OS+kI3XqxiirxOotZl8J8cjBr8qjd+u2Q5G5o8J6JZXps39MxkNxlzRKuexSM2yeOnzA4ofqu7cAHNkHIvUYNuX8TQTmZ5XXQgugRUOGoEACeTUIcVjSTWZCQng3tfR+mFZ99GXCbwfyd1gGbYhAh8wtafk/jFFRA3euqSFTHrRuzQg3Vg9FZCRie11ltNk0yuo=

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 # Move build artefacts to public folder so they are published on the demo site.
 - mv webpack/webpack-stats.html public || true
 - mv coverage/lcov-report public || true
+- npm run report:size
 after_success:
 - cat ./coverage/lcov.info | coveralls
 branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,236 +8,236 @@
 
 ### Changed
 
-* Unsupported actions causing an atomic block to be without entity now soft-fail with an un-editable atomic block instead of hard-fail [wagtail/wagtail#4370](https://github.com/wagtail/wagtail/issues/4370).
+*   Unsupported actions causing an atomic block to be without entity now soft-fail with an un-editable atomic block instead of hard-fail [wagtail/wagtail#4370](https://github.com/wagtail/wagtail/issues/4370).
 
 ### Fixed
 
-* Add workaround for RichUtils image delete blind spot reported in [wagtail/wagtail#4370](https://github.com/wagtail/wagtail/issues/4370) ([#144](https://github.com/springload/draftail/pull/144)).
+*   Add workaround for RichUtils image delete blind spot reported in [wagtail/wagtail#4370](https://github.com/wagtail/wagtail/issues/4370) ([#144](https://github.com/springload/draftail/pull/144)).
 
 ## [[v0.17.0]](https://github.com/springload/draftail/releases/tag/v0.17.0)
 
 ### Added
 
-* Add basic API for arbitrary controls in the toolbar.
-* Expose `ToolbarButton` component in the API.
-* Add ability to set `ariaDescribedBy` prop of Draft.js.
+*   Add basic API for arbitrary controls in the toolbar.
+*   Expose `ToolbarButton` component in the API.
+*   Add ability to set `ariaDescribedBy` prop of Draft.js.
 
 ### Changed
 
-* Replace block entities by a paragraph when using `onRemoveEntity`.
-* Replace `ListNesting` implementation with the one from `draftjs-conductor`.
+*   Replace block entities by a paragraph when using `onRemoveEntity`.
+*   Replace `ListNesting` implementation with the one from `draftjs-conductor`.
 
 ### Fixed
 
-* Fix copy-paste filter running more often than necessary.
-* Use darker placeholder text color to pass WCAG2.0 AAA level contrast ratio. Overridable via `$draftail-placeholder-text`.
-* Fix HR block spacing at the top of the editor.
+*   Fix copy-paste filter running more often than necessary.
+*   Use darker placeholder text color to pass WCAG2.0 AAA level contrast ratio. Overridable via `$draftail-placeholder-text`.
+*   Fix HR block spacing at the top of the editor.
 
 ### Removed
 
-* Remove `DraftUtils.isSelectedBlockType()`.
-* Remove `DraftUtils.hasCurrentInlineStyle()`.
+*   Remove `DraftUtils.isSelectedBlockType()`.
+*   Remove `DraftUtils.hasCurrentInlineStyle()`.
 
 ## [[v0.16.0]](https://github.com/springload/draftail/releases/tag/v0.16.0)
 
 ### Changed
 
-* Remove toolbar z-index when the editor is not focused, to reduce chances of interferring with other components.
-* Adjust toolbar button alignment for text-only buttons.
-* Replace `className` prop for blocks by dynamically adding a class based on block type.
-* Update to `draftjs-filters@0.7.0` to preserve list items in Word.
-* Update `draft-js` peerDependency version to 0.10.5.
+*   Remove toolbar z-index when the editor is not focused, to reduce chances of interferring with other components.
+*   Adjust toolbar button alignment for text-only buttons.
+*   Replace `className` prop for blocks by dynamically adding a class based on block type.
+*   Update to `draftjs-filters@0.7.0` to preserve list items in Word.
+*   Update `draft-js` peerDependency version to 0.10.5.
 
 ### Fixed
 
-* Fix Markdown shortcuts for blocks removing styles and entities at the end of the block text.
+*   Fix Markdown shortcuts for blocks removing styles and entities at the end of the block text.
 
 ### Removed
 
-* Remove React 15 from peerDependencies.
+*   Remove React 15 from peerDependencies.
 
 ## [[v0.15.0]](https://github.com/springload/draftail/releases/tag/v0.15.0)
 
 ### Changed
 
-* Replace nested-list-items Sass helper with new auto-generated CSS in JS.
-* Update to `draftjs-filters@0.6.1` to fix entities not being cloned on paste.
+*   Replace nested-list-items Sass helper with new auto-generated CSS in JS.
+*   Update to `draftjs-filters@0.6.1` to fix entities not being cloned on paste.
 
 ### Removed
 
-* Remove support for `maxListNesting` greater than 10.
+*   Remove support for `maxListNesting` greater than 10.
 
 ## [[v0.14.0]](https://github.com/springload/draftail/releases/tag/v0.14.0)
 
 ### Added
 
-* Make line break and horizontal line controls configurable, by passing an object with `icon`, `label`, `description` props.
-* Add ability to set `textAlignment`, `textDirectionality`, `autoCapitalize`, `autoComplete`, `autoCorrect` props of Draft.js.
+*   Make line break and horizontal line controls configurable, by passing an object with `icon`, `label`, `description` props.
+*   Add ability to set `textAlignment`, `textDirectionality`, `autoCapitalize`, `autoComplete`, `autoCorrect` props of Draft.js.
 
 ### Changed
 
-* Rename `DraftUtils.addLineBreakRemovingSelection` to `DraftUtils.addLineBreak`.
-* Replace `showUndoRedoControls` with separate props `showUndoControl` and `showRedoControl` for which control UI can be overriden.
-* Make all keyboard shortcut labels language agnostic.
+*   Rename `DraftUtils.addLineBreakRemovingSelection` to `DraftUtils.addLineBreak`.
+*   Replace `showUndoRedoControls` with separate props `showUndoControl` and `showRedoControl` for which control UI can be overriden.
+*   Make all keyboard shortcut labels language agnostic.
 
 ### Fixed
 
-* Fix `DraftUtils.addLineBreak` adding line breaks in the wrong place when selection is collapsed.
+*   Fix `DraftUtils.addLineBreak` adding line breaks in the wrong place when selection is collapsed.
 
 ## [[v0.13.0]](https://github.com/springload/draftail/releases/tag/v0.13.0)
 
 ### Added
 
-* Add default block spacing to make it easier to distinguish empty blocks.
+*   Add default block spacing to make it easier to distinguish empty blocks.
 
 ### Changed
 
-* Make rich text styles specific to Draftail.
-* Update to `draftjs-filters@0.5.0` to improve filtering on [undefined attributes](https://github.com/thibaudcolas/draftjs-filters/commit/f836563).
-* Update editor read-only styles to integrate better with any background color.
+*   Make rich text styles specific to Draftail.
+*   Update to `draftjs-filters@0.5.0` to improve filtering on [undefined attributes](https://github.com/thibaudcolas/draftjs-filters/commit/f836563).
+*   Update editor read-only styles to integrate better with any background color.
 
 ### Fixed
 
-* Prevent toolbar tooltip from having a transition delay on close.
-* Prevent toolbar tooltip from staying open when hovered.
+*   Prevent toolbar tooltip from having a transition delay on close.
+*   Prevent toolbar tooltip from staying open when hovered.
 
 ## [[v0.12.0]](https://github.com/springload/draftail/releases/tag/v0.12.0)
 
 ### Added
 
-* Add `Draftail-unstyled` class to unstyled block, makes it easy to style unstyled blocks.
-* Add `$draftail-editor-background` variable to override editor bg.
-* Add `draftail-richtext-styles` mixin to style rich text content within the editor.
-* Add imperative `focus()` API to the editor, like that of Draft.js.
-* Add `onClose` prop to sources, to close the source without focusing the editor again.
+*   Add `Draftail-unstyled` class to unstyled block, makes it easy to style unstyled blocks.
+*   Add `$draftail-editor-background` variable to override editor bg.
+*   Add `draftail-richtext-styles` mixin to style rich text content within the editor.
+*   Add imperative `focus()` API to the editor, like that of Draft.js.
+*   Add `onClose` prop to sources, to close the source without focusing the editor again.
 
 ### Changed
 
-* Make all icons `vertical-align: middle;` by default.
-* Update to `draftjs-filters@0.4.0` to allow filtering on [undefined attributes](https://github.com/thibaudcolas/draftjs-filters/commit/a4af845).
+*   Make all icons `vertical-align: middle;` by default.
+*   Update to `draftjs-filters@0.4.0` to allow filtering on [undefined attributes](https://github.com/thibaudcolas/draftjs-filters/commit/a4af845).
 
 ### Fixed
 
-* Fix icons / labels alignment in the toolbar.
+*   Fix icons / labels alignment in the toolbar.
 
 ## [[v0.11.0]](https://github.com/springload/draftail/releases/tag/v0.11.0)
 
 ### Added
 
-* Add new Sass constants to make the editor more themable: `$draftail-editor-padding, $draftail-editor-text, $draftail-editor-font-family, $draftail-editor-font-size, $draftail-editor-line-height, $draftail-toolbar-radius, $draftail-editor-border, $draftail-toolbar-tooltip-radius, $draftail-toolbar-tooltip-duration, $draftail-toolbar-tooltip-delay`.
-* Delay toolbar tooltip opening on hover by 0.5s, animated over 0.1s.
-* Make Markdown-style markers work on non-empty blocks ([#53](https://github.com/springload/draftail/issues/53)).
+*   Add new Sass constants to make the editor more themable: `$draftail-editor-padding, $draftail-editor-text, $draftail-editor-font-family, $draftail-editor-font-size, $draftail-editor-line-height, $draftail-toolbar-radius, $draftail-editor-border, $draftail-toolbar-tooltip-radius, $draftail-toolbar-tooltip-duration, $draftail-toolbar-tooltip-delay`.
+*   Delay toolbar tooltip opening on hover by 0.5s, animated over 0.1s.
+*   Make Markdown-style markers work on non-empty blocks ([#53](https://github.com/springload/draftail/issues/53)).
 
 ### Changed
 
-* Switch to rollup for package compilation.
-* Move `DraftailEditor` from default export of draftail to named export (`import { DraftailEditor } from 'draftail';`).
-* Wrap `propTypes` in env check so they only appear in dev build.
-* Rename / namespace all overridable Sass constants.
-* Rename `nested-list-item($depth)` to `draftail-nested-list-item($depth)`.
-* Stop defining `$draftail-tooltip-radius` based on `$draftail-editor-radius`.
-* Simplify `DraftUtils.getSelectedBlock()` implementation.
-* Rename `options` prop to `entityType` for entity sources.
-* Rename `onUpdate` prop to `onComplete` for entity sources.
-* Rename `entityConfig` prop to `entityType` for entity blocks.
-* Replace normalize API with `draftjs-filters` ([#123](https://github.com/springload/draftail/issues/123)).
-* Update toolbar tooltips to show markdown markers for all blocks.
+*   Switch to rollup for package compilation.
+*   Move `DraftailEditor` from default export of draftail to named export (`import { DraftailEditor } from 'draftail';`).
+*   Wrap `propTypes` in env check so they only appear in dev build.
+*   Rename / namespace all overridable Sass constants.
+*   Rename `nested-list-item($depth)` to `draftail-nested-list-item($depth)`.
+*   Stop defining `$draftail-tooltip-radius` based on `$draftail-editor-radius`.
+*   Simplify `DraftUtils.getSelectedBlock()` implementation.
+*   Rename `options` prop to `entityType` for entity sources.
+*   Rename `onUpdate` prop to `onComplete` for entity sources.
+*   Rename `entityConfig` prop to `entityType` for entity blocks.
+*   Replace normalize API with `draftjs-filters` ([#123](https://github.com/springload/draftail/issues/123)).
+*   Update toolbar tooltips to show markdown markers for all blocks.
 
 ### Fixed
 
-* Prevent toolbar button labels from being selected.
-* Fix newline block insertion & reset creating 2 entries in undo stack ([#105](https://github.com/springload/draftail/issues/105)).
+*   Prevent toolbar button labels from being selected.
+*   Fix newline block insertion & reset creating 2 entries in undo stack ([#105](https://github.com/springload/draftail/issues/105)).
 
 ### Removed
 
-* Remove all unused variables from Sass constants.
-* Remove `immutable` from `peerDependencies`.
-* Remove `draftjs-utils` from `dependencies`.
-* Remove `DraftUtils.createEntity()`.
-* Remove `DraftUtils.getAllBlocks()`.
-* Remove `DraftUtils.getEntityRange()`.
-* Remove `onClose` prop for entity sources.
+*   Remove all unused variables from Sass constants.
+*   Remove `immutable` from `peerDependencies`.
+*   Remove `draftjs-utils` from `dependencies`.
+*   Remove `DraftUtils.createEntity()`.
+*   Remove `DraftUtils.getAllBlocks()`.
+*   Remove `DraftUtils.getEntityRange()`.
+*   Remove `onClose` prop for entity sources.
 
 ## [[v0.10.0]](https://github.com/springload/draftail/releases/tag/v0.10.0)
 
 ### Added
 
-* Add new `DraftUtils.getEntitySelection(editorState, entityKey)` method, returning the selection corresponding to a given entity. Note: only works if the entity is in the currently selected block.
-* Add `DraftUtils.updateBlockEntity` method, with workaround for Draft.s 0.10 entity data update bug.
-* Add shortcuts for blockquote and code block to toolbar tooltips.
-* Use alternative keyboard shortcuts for more formats.
-* Add default labels & descriptions for built-in formats ([#122](https://github.com/springload/draftail/issues/122)).
-* Process, whitelist, blacklist, migrate available blocks, styles and entities when pasting rich text ([#50](https://github.com/springload/draftail/pull/50) & [#103](https://github.com/springload/draftail/pull/103) thanks to [@inostia](https://github.com/inostia), see [#123](https://github.com/springload/draftail/issues/123) for next steps).
-* Add support for custom text decorators ([#121](https://github.com/springload/draftail/issues/121)).
-* Add predefined classes for block depth levels above 4, of the format `public-DraftStyleDefault-depth${depth}`.
-* Add `nested-list-item($depth)` Sass mixin to generate styles for arbitrary list item nesting.
-* Introduce new `Draftail-` class namespace for all styles ([#63](https://github.com/springload/draftail/issues/63)).
-* Expose Sass stylesheets to Draftail users, for extension.
+*   Add new `DraftUtils.getEntitySelection(editorState, entityKey)` method, returning the selection corresponding to a given entity. Note: only works if the entity is in the currently selected block.
+*   Add `DraftUtils.updateBlockEntity` method, with workaround for Draft.s 0.10 entity data update bug.
+*   Add shortcuts for blockquote and code block to toolbar tooltips.
+*   Use alternative keyboard shortcuts for more formats.
+*   Add default labels & descriptions for built-in formats ([#122](https://github.com/springload/draftail/issues/122)).
+*   Process, whitelist, blacklist, migrate available blocks, styles and entities when pasting rich text ([#50](https://github.com/springload/draftail/pull/50) & [#103](https://github.com/springload/draftail/pull/103) thanks to [@inostia](https://github.com/inostia), see [#123](https://github.com/springload/draftail/issues/123) for next steps).
+*   Add support for custom text decorators ([#121](https://github.com/springload/draftail/issues/121)).
+*   Add predefined classes for block depth levels above 4, of the format `public-DraftStyleDefault-depth${depth}`.
+*   Add `nested-list-item($depth)` Sass mixin to generate styles for arbitrary list item nesting.
+*   Introduce new `Draftail-` class namespace for all styles ([#63](https://github.com/springload/draftail/issues/63)).
+*   Expose Sass stylesheets to Draftail users, for extension.
 
 ### Changed
 
-* Exclude toolbar buttons from default focus navigation flow.
-* Disable ligatures in the editor, to simplify cursor behaviour.
-* Stop bundling the Draft.js styles. They now have to be manually included. The previous approach was prone to version mismatches.
-* Configure text antialiasing for Firefox.
-* Change `Icon` implementation to use SVG by default. Supports symbol references, SVG path(s), and arbitrary React components ([#119](https://github.com/springload/draftail/issues/119)).
-* Disable pointer events on all icons by default.
-* Remove toolbar hover styles.
-* Make more of the editor styling overridable.
-* Move `Tooltip` outside of Draftail package.
-* Refactor tooltip for inline entities to be defined directly in decorators. They should now define their own tooltip (or other control), rather than rely on `data-tooltip`.
-* Move `Portal` component outside of Draftail.
-* Add `block` prop to entityTypes, and move `IMAGE` and `EMBED` blocks outside of Draftail ([#121](https://github.com/springload/draftail/issues/121)).
-* Provide methods for `entityTypes`' `block` to edit, remove entity.
+*   Exclude toolbar buttons from default focus navigation flow.
+*   Disable ligatures in the editor, to simplify cursor behaviour.
+*   Stop bundling the Draft.js styles. They now have to be manually included. The previous approach was prone to version mismatches.
+*   Configure text antialiasing for Firefox.
+*   Change `Icon` implementation to use SVG by default. Supports symbol references, SVG path(s), and arbitrary React components ([#119](https://github.com/springload/draftail/issues/119)).
+*   Disable pointer events on all icons by default.
+*   Remove toolbar hover styles.
+*   Make more of the editor styling overridable.
+*   Move `Tooltip` outside of Draftail package.
+*   Refactor tooltip for inline entities to be defined directly in decorators. They should now define their own tooltip (or other control), rather than rely on `data-tooltip`.
+*   Move `Portal` component outside of Draftail.
+*   Add `block` prop to entityTypes, and move `IMAGE` and `EMBED` blocks outside of Draftail ([#121](https://github.com/springload/draftail/issues/121)).
+*   Provide methods for `entityTypes`' `block` to edit, remove entity.
 
 ### Removed
 
-* Remove Save and Cancel buttons from image block, thanks to [@allcaps](https://github.com/allcaps) ([#102](https://github.com/springload/draftail/pull/102))
-* Remove `DraftUtils.getSelectedEntitySelection`. It can be replaced by `DraftUtils.getEntitySelection(editorState, DraftUtils.getSelectionEntity(editorState))`.
-* Remove built-in support for `MODEL` entities.
-* Remove built-in support for `EMBED` entities.
-* Remove built-in support for `DOCUMENT` entities.
-* Remove support for `entityTypes`' `imageFormats`.
-* Remove support for custom `entityTypes` `strategy`.
+*   Remove Save and Cancel buttons from image block, thanks to [@allcaps](https://github.com/allcaps) ([#102](https://github.com/springload/draftail/pull/102))
+*   Remove `DraftUtils.getSelectedEntitySelection`. It can be replaced by `DraftUtils.getEntitySelection(editorState, DraftUtils.getSelectionEntity(editorState))`.
+*   Remove built-in support for `MODEL` entities.
+*   Remove built-in support for `EMBED` entities.
+*   Remove built-in support for `DOCUMENT` entities.
+*   Remove support for `entityTypes`' `imageFormats`.
+*   Remove support for custom `entityTypes` `strategy`.
 
 ### Fixed
 
-* Update handleNewLine to defer breakout in code-block. Fix [#104](https://github.com/springload/draftail/issues/104).
-* Fix toolbar entity edit and remove not working on selection pre first char. Fix [#109](https://github.com/springload/draftail/issues/109).
-* Fix block type transformations moving selection to the wrong block.
-* Fix editor scrolling in the wrong position when breaking a big block (https://github.com/facebook/draft-js/issues/304#issuecomment-327606596).
+*   Update handleNewLine to defer breakout in code-block. Fix [#104](https://github.com/springload/draftail/issues/104).
+*   Fix toolbar entity edit and remove not working on selection pre first char. Fix [#109](https://github.com/springload/draftail/issues/109).
+*   Fix block type transformations moving selection to the wrong block.
+*   Fix editor scrolling in the wrong position when breaking a big block (https://github.com/facebook/draft-js/issues/304#issuecomment-327606596).
 
 ## [[v0.9.0]](https://github.com/springload/draftail/releases/tag/v0.9.0)
 
 ### Added
 
-* Add support for [custom inline styles](https://github.com/springload/draftail#custom-inline-styles), thanks to [@vincentaudebert](https://github.com/vincentaudebert) ([#97](https://github.com/springload/draftail/pull/97)).
-* Add [basic styles](https://github.com/springload/draftail/blob/60f2f6ef5684c10c7c409a6333f2b157b955fa45/lib/api/constants.js#L51) for common inline styles.
-* Add new `description` prop for all formats to describe the format's use with more text than the `label`.
-* Add tooltips for toolbar buttons to display the full control `description` as well as its keyboard shortcut.
-* Add separate button groups in the toolbar.
-* Add basic undo/redo controls in the toolbar ([#100](https://github.com/springload/draftail/pull/100)), displaying the related keyboard shortcuts.
-* Introduce icons for hr: `―` and br: `↵`.
-* Add keyboard shortcuts for superscript & subscript.
-* Add more Markdown-like markers for heading levels (`##`), code block (triple backtick), blockquote (`>`), hr (`---`) ([#53](https://github.com/springload/draftail/issues/53)).
-* Add `spellCheck` prop, passed to Draft.js `Editor`. Sets whether spellcheck is turned on for your editor.
-* Add support for React 16.
+*   Add support for [custom inline styles](https://github.com/springload/draftail#custom-inline-styles), thanks to [@vincentaudebert](https://github.com/vincentaudebert) ([#97](https://github.com/springload/draftail/pull/97)).
+*   Add [basic styles](https://github.com/springload/draftail/blob/60f2f6ef5684c10c7c409a6333f2b157b955fa45/lib/api/constants.js#L51) for common inline styles.
+*   Add new `description` prop for all formats to describe the format's use with more text than the `label`.
+*   Add tooltips for toolbar buttons to display the full control `description` as well as its keyboard shortcut.
+*   Add separate button groups in the toolbar.
+*   Add basic undo/redo controls in the toolbar ([#100](https://github.com/springload/draftail/pull/100)), displaying the related keyboard shortcuts.
+*   Introduce icons for hr: `―` and br: `↵`.
+*   Add keyboard shortcuts for superscript & subscript.
+*   Add more Markdown-like markers for heading levels (`##`), code block (triple backtick), blockquote (`>`), hr (`---`) ([#53](https://github.com/springload/draftail/issues/53)).
+*   Add `spellCheck` prop, passed to Draft.js `Editor`. Sets whether spellcheck is turned on for your editor.
+*   Add support for React 16.
 
 ### Changed
 
-* Update keyboard shortcuts format to follow that of Google Docs.
-* Refine toolbar styles. Fix toolbar to the top of the page when sticky.
-* Make the editor look closer to a textarea ([#96](https://github.com/springload/draftail/issue/96)).
-* Update strikethrough shortcut from Google Docs.
-* Update Draft.js dependency to 0.10.4, and `draftjs-utils` to 0.8.8.
-* Stop preserving Markdown-like block marker when undoing block type change.
-* Stop restricting block type changes based on Markdown-style markers to unstyled blocks only.
+*   Update keyboard shortcuts format to follow that of Google Docs.
+*   Refine toolbar styles. Fix toolbar to the top of the page when sticky.
+*   Make the editor look closer to a textarea ([#96](https://github.com/springload/draftail/issue/96)).
+*   Update strikethrough shortcut from Google Docs.
+*   Update Draft.js dependency to 0.10.4, and `draftjs-utils` to 0.8.8.
+*   Stop preserving Markdown-like block marker when undoing block type change.
+*   Stop restricting block type changes based on Markdown-style markers to unstyled blocks only.
 
 ### Fixed
 
-* Fix tooltip position when scrolling ([#99](https://github.com/springload/draftail/pull/99)).
-* Fix beforeInput text replacement happening on non-collapsed selections.
-* Prevent text inserted after entities from continuing the entity. Fix [#86](https://github.com/springload/draftail/issue/86) ([#106](https://github.com/springload/draftail/pull/106)).
+*   Fix tooltip position when scrolling ([#99](https://github.com/springload/draftail/pull/99)).
+*   Fix beforeInput text replacement happening on non-collapsed selections.
+*   Prevent text inserted after entities from continuing the entity. Fix [#86](https://github.com/springload/draftail/issue/86) ([#106](https://github.com/springload/draftail/pull/106)).
 
 ### How to upgrade
 
@@ -269,145 +269,145 @@ blockTypes={[
 
 ### Added
 
-* Add `name` attribute to button elements to simplify targeting in browser automation tests.
-* Publish the package as an ES2015 module.
+*   Add `name` attribute to button elements to simplify targeting in browser automation tests.
+*   Publish the package as an ES2015 module.
 
 ### Changed
 
-* Upgrade draftjs-utils to latest (draftjs-utils).
-* Use references to window object instead of global.
-* Update dependencies to remove Immutable.js duplication
+*   Upgrade draftjs-utils to latest (draftjs-utils).
+*   Use references to window object instead of global.
+*   Update dependencies to remove Immutable.js duplication
 
 ## [[v0.7.3]](https://github.com/springload/draftail/releases/tag/v0.7.3)
 
 ### Added
 
-* Expose reusable Portal component as part of the API.
+*   Expose reusable Portal component as part of the API.
 
 ## [[v0.7.2]](https://github.com/springload/draftail/releases/tag/v0.7.2)
 
 ### Changed
 
-* Only stick toolbar when editor is active.
-* Make editor slightly bigger.
+*   Only stick toolbar when editor is active.
+*   Make editor slightly bigger.
 
 ### Fixed
 
-* Fix `editor` class name concatenation.
+*   Fix `editor` class name concatenation.
 
 ## [[v0.7.1]](https://github.com/springload/draftail/releases/tag/v0.7.1)
 
 ### Fixed
 
-* Fix CSS import present in published library.
+*   Fix CSS import present in published library.
 
 ## [[v0.7.0]](https://github.com/springload/draftail/releases/tag/v0.7.0)
 
 ### Added
 
-* Make the editor toolbar sticky (requires a polyfill, documented in README).
-* Add support for `placeholder` attribute.
+*   Make the editor toolbar sticky (requires a polyfill, documented in README).
+*   Add support for `placeholder` attribute.
 
 ### Changed
 
-* Improve "active block" rendering and disabled state.
+*   Improve "active block" rendering and disabled state.
 
 ### Fixed
 
-* Fix missing vertical spacing between button rows.
-* Fix missing pointer cursor on tooltip button.
+*   Fix missing vertical spacing between button rows.
+*   Fix missing pointer cursor on tooltip button.
 
 ### Removed
 
-* Remove `Element.closest` polyfill from main lib.
+*   Remove `Element.closest` polyfill from main lib.
 
 ## [[v0.6.0]](https://github.com/springload/draftail/releases/tag/v0.6.0)
 
 ### Added
 
-* Add default `strategy` for entity types based on `type`.
+*   Add default `strategy` for entity types based on `type`.
 
 ### Changed
 
-* Change empty `RawDraftContentState` in conversion API to be null.
-* Change entity type nomenclature to use `source` and `decorator` in place of `control` and `component`.
+*   Change empty `RawDraftContentState` in conversion API to be null.
+*   Change entity type nomenclature to use `source` and `decorator` in place of `control` and `component`.
 
 ## [[v0.5.0]](https://github.com/springload/draftail/releases/tag/v0.5.0)
 
 ### Added
 
-* Implement list depth normalisation on copy/paste.
-* Add title attributes on buttons to display keyboard shortcuts. Fix #37.
-* Override default code-block element. Fix #41.
+*   Implement list depth normalisation on copy/paste.
+*   Add title attributes on buttons to display keyboard shortcuts. Fix #37.
+*   Override default code-block element. Fix #41.
 
 ### Changed
 
-* Update project to use draft-js@0.10 API
-* Move draftjs-utils `peerDependency` to be a dependency.
-* Move immutable `peerDependency` to be a dependency.
-* Copy/paste of rich text is now configurable via the `stripPastedStyles` option.
-* Copy/paste of rich text is now disabled by default. This will be enabled by default once it is better supported.
+*   Update project to use draft-js@0.10 API
+*   Move draftjs-utils `peerDependency` to be a dependency.
+*   Move immutable `peerDependency` to be a dependency.
+*   Copy/paste of rich text is now configurable via the `stripPastedStyles` option.
+*   Copy/paste of rich text is now disabled by default. This will be enabled by default once it is better supported.
 
 ## [[v0.4.1]](https://github.com/springload/draftail/releases/tag/v0.4.1)
 
 ### Fixed
 
-* Fix image block not unlocking editor on cancel.
+*   Fix image block not unlocking editor on cancel.
 
 ## [[v0.4.0]](https://github.com/springload/draftail/releases/tag/v0.4.0)
 
 ### Added
 
-* Make `hr` availability configurable with `enableHorizontalRule`. #25.
-* Add `br` support, availability configurable with `enableLineBreak`.
-* Prevent soft line breaks from keyboard shortcut if disabled.
-* Add editor CSS to published package. #17
-* Add common keyboard shortcuts (inspired by Google Docs, see documentation for the full list).
-* Add support for "autolist" behavior (lines starting with `-`, `*`, `1.` are automatically converted to list items).
+*   Make `hr` availability configurable with `enableHorizontalRule`. #25.
+*   Add `br` support, availability configurable with `enableLineBreak`.
+*   Prevent soft line breaks from keyboard shortcut if disabled.
+*   Add editor CSS to published package. #17
+*   Add common keyboard shortcuts (inspired by Google Docs, see documentation for the full list).
+*   Add support for "autolist" behavior (lines starting with `-`, `*`, `1.` are automatically converted to list items).
 
 ### Changed
 
-* Max nested list level is now 1.
-* Max nested list level is now configurable via a prop.
-* Save interval is now configurable via a prop.
-* Change `hr` representation to use atomic block and entity instead of custom block type. #1
-* `mediaControls`, `dialogControls` and `modelPickerOptions` are now a single `entityTypes` array. #26
-* `sources` and `decorators` are now declared directly in the `entityTypes` array items.
-* `INLINE_STYLES` property is now `inlineStyles`.
-* `BLOCK_TYPES` property is now `blockTypes`.
-* Inline styles and block types now use the `type` attribute instead of `style`.
-* `imageFormats` are now assigned directly on the `IMAGE` entity type. #33
-* All options are now direct props of `DraftailEditor` instead of attributes of the `options` prop. #21
+*   Max nested list level is now 1.
+*   Max nested list level is now configurable via a prop.
+*   Save interval is now configurable via a prop.
+*   Change `hr` representation to use atomic block and entity instead of custom block type. #1
+*   `mediaControls`, `dialogControls` and `modelPickerOptions` are now a single `entityTypes` array. #26
+*   `sources` and `decorators` are now declared directly in the `entityTypes` array items.
+*   `INLINE_STYLES` property is now `inlineStyles`.
+*   `BLOCK_TYPES` property is now `blockTypes`.
+*   Inline styles and block types now use the `type` attribute instead of `style`.
+*   `imageFormats` are now assigned directly on the `IMAGE` entity type. #33
+*   All options are now direct props of `DraftailEditor` instead of attributes of the `options` prop. #21
 
 ### Fixed
 
-* Fix erratic behavior of list nesting changes with tab and shift+tab shortcuts. #34
-* Fix keyboard shortcuts giving access to unallowed formatting. #32
-* Fix tooltip not opening when clicking decorator icon. #5
+*   Fix erratic behavior of list nesting changes with tab and shift+tab shortcuts. #34
+*   Fix keyboard shortcuts giving access to unallowed formatting. #32
+*   Fix tooltip not opening when clicking decorator icon. #5
 
 ### Removed
 
-* draftail no longer depends on jQuery.
-* draftail no longer depends on the Wagtail font icon.
+*   draftail no longer depends on jQuery.
+*   draftail no longer depends on the Wagtail font icon.
 
 ## [[v0.3.3]](https://github.com/springload/draftail/releases/tag/v0.3.3)
 
 ### Added
 
-* Allow customisation of block style function & block render map.
+*   Allow customisation of block style function & block render map.
 
 ## [[v0.3.2]](https://github.com/springload/draftail/releases/tag/v0.3.2)
 
 ### Added
 
-* Pressing return on an empty list item should un-indent it until it is not nested, and then remove it.
-* Pressing return at the end of a block should create an empty unstyled block.
+*   Pressing return on an empty list item should un-indent it until it is not nested, and then remove it.
+*   Pressing return at the end of a block should create an empty unstyled block.
 
 ## [[v0.3.1]](https://github.com/springload/draftail/releases/tag/v0.3.1)
 
 ### Fixed
 
-* Buttons do not trigger a form submit
+*   Buttons do not trigger a form submit
 
 ## [[v0.3.0]](https://github.com/springload/draftail/releases/tag/v0.3.0)
 
@@ -415,24 +415,24 @@ blockTypes={[
 
 ### Added
 
-* Keyboard shortcuts documentation
+*   Keyboard shortcuts documentation
 
 ### Changed
 
-* Expose onSave hook instead of auto field saving (https://github.com/springload/draftail/issues/23)
+*   Expose onSave hook instead of auto field saving (https://github.com/springload/draftail/issues/23)
 
 ### Fixed
 
-* https://github.com/springload/draftail/issues/2
-* https://github.com/springload/draftail/issues/3
-* https://github.com/springload/draftail/issues/28
+*   https://github.com/springload/draftail/issues/2
+*   https://github.com/springload/draftail/issues/3
+*   https://github.com/springload/draftail/issues/28
 
 ## [[v0.2.0]](https://github.com/springload/draftail/releases/tag/v0.2.0)
 
 ### Changed
 
-* Reworking most of the editor codebase to make it more maintainable.
-* Configurable block types and inline styles.
+*   Reworking most of the editor codebase to make it more maintainable.
+*   Configurable block types and inline styles.
 
 ## [[v0.1.0]](https://github.com/springload/draftail/releases/tag/v0.1.0)
 
@@ -446,7 +446,7 @@ Template from http://keepachangelog.com/
 
 ### Added
 
-* Something was added to the API / a new feature was introduced.
+*   Something was added to the API / a new feature was introduced.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Draftail aims for a mouse-free, keyboard-centric experience. Most formatting can
 
 Here are important features worth highlighting:
 
-* Support for [keyboard shortcuts](/docs/user-guide/README.md). Lots of them!
-* Paste from Word. Or any other editor.
-* Autolists – start a line with `-` , `*` , `1.` to create a list item.
-* Shortcuts for heading levels `##`, code blocks ` ``` `, and more.
-* Undo / redo – until the end of times.
-* Common text types: headings, paragraphs, quotes, lists.
-* Common text styles: Bold, italic, and many more.
-* API to build custom controls for links, images, and more.
+*   Support for [keyboard shortcuts](/docs/user-guide/README.md). Lots of them!
+*   Paste from Word. Or any other editor.
+*   Autolists – start a line with `-` , `*` , `1.` to create a list item.
+*   Shortcuts for heading levels `##`, code blocks ` ``` `, and more.
+*   Undo / redo – until the end of times.
+*   Common text types: headings, paragraphs, quotes, lists.
+*   Common text styles: Bold, italic, and many more.
+*   API to build custom controls for links, images, and more.
 
 ## Using Draftail
 
@@ -31,9 +31,9 @@ Draftail is meant to be used in scenarios where not all formatting should be ava
 
 ### Built-in formats
 
-* Block types: H1, H2, H3, H4, H5, H6, Blockquote, Code, UL, OL, P
-* Inline styles: Bold, Italic, Underline, Code, Strikethrough, Mark, Keyboard, Superscript, Subscript
-* And HR, BR
+*   Block types: H1, H2, H3, H4, H5, H6, Blockquote, Code, UL, OL, P
+*   Inline styles: Bold, Italic, Underline, Code, Strikethrough, Mark, Keyboard, Superscript, Subscript
+*   And HR, BR
 
 Draftail does not come with built-in controls for things like images and links, so you can build your own exactly as you wish. This is particularly useful when integrating with content sources, like a CMS, an API, or other tools with a fixed schema.
 
@@ -154,9 +154,9 @@ stateSaveInterval: 250,
 
 Draftail, like Draft.js, distinguishes between 3 content formats:
 
-* Blocks, that provide structure to the content. Blocks do not overlap – no content can be both a paragraph and a title.
-* Inline styles, providing inline formatting for text. Styles can overlap: a piece of text can be both bold and italic.
-* Entities, annotating content with metadata to represent rich content beyond text. Entities can be inline (eg. a link applied on a portion of text), or block-based (eg. an embedded video).
+*   Blocks, that provide structure to the content. Blocks do not overlap – no content can be both a paragraph and a title.
+*   Inline styles, providing inline formatting for text. Styles can overlap: a piece of text can be both bold and italic.
+*   Entities, annotating content with metadata to represent rich content beyond text. Entities can be inline (eg. a link applied on a portion of text), or block-based (eg. an embedded video).
 
 ### Configuring available formats
 
@@ -315,9 +315,9 @@ Creating custom entity types is a bit more involved because entities aren't simp
 
 Apart from the usual type/label/description/icon options, entities need:
 
-* A `source`, a React component that will be rendered to display the UI when creating or editing an entity. This could involve a modal window, API calls, a tooltip, or any other mean of gathering entity data.
-* A `decorator`, a React component to display the entity within the editor area for inline entities (eg. links).
-* Finally, the `block` is for block-level entities (think: image block, embed) to supply their React component.
+*   A `source`, a React component that will be rendered to display the UI when creating or editing an entity. This could involve a modal window, API calls, a tooltip, or any other mean of gathering entity data.
+*   A `decorator`, a React component to display the entity within the editor area for inline entities (eg. links).
+*   Finally, the `block` is for block-level entities (think: image block, embed) to supply their React component.
 
 Optionally, entities can also take an `attributes` and `whitelist` props. These can be used to determine whitelisting rules when pasting content into the editor, to only keep the entities considered valid. If undefined, all entities are always preserved with all of their data.
 
@@ -502,9 +502,9 @@ $draftail-editor-z-index: 100;
 
 Draftail can use icons to display each format in the toolbar. There are multiple possible formats:
 
-* A `<path />` data string (the `d` attribute), eg `'M10 10 H 90 V 90 H 10 Z'`.
-* An array of paths, eg. `['M10 10 H 90 V 90 H 10 Z', 'M10 10 H 90 V 90 H 10 Z']`.
-* An SVG symbol reference, inline or external eg. `#square` / `test.svg#square`.
+*   A `<path />` data string (the `d` attribute), eg `'M10 10 H 90 V 90 H 10 Z'`.
+*   An array of paths, eg. `['M10 10 H 90 V 90 H 10 Z', 'M10 10 H 90 V 90 H 10 Z']`.
+*   An SVG symbol reference, inline or external eg. `#square` / `test.svg#square`.
 
 The SVG has to use a 1024x1024 viewbox that will be downscaled to 16x16.
 
@@ -545,8 +545,8 @@ Without Sass, refer to class names starting with `Draftail-` or `Draft` / `publi
 
 The editor comes with default labels in english, but all are overridable.
 
-* For blocks, styles, and entities, use the `label` and-or `description` prop to set text in the right language.
-* For boolean controls (`enableLineBreak`, etc), set instead an object with `icon`, `label`, `description` props (all optional).
+*   For blocks, styles, and entities, use the `label` and-or `description` prop to set text in the right language.
+*   For boolean controls (`enableLineBreak`, etc), set instead an object with `icon`, `label`, `description` props (all optional).
 
 Depending on the target language, you may also need to use the `textDirectionality` prop (`LTR` or `RTL`). See the full [Draft.js documentation](https://draftjs.org/docs/api-reference-editor.html#textdirectionality) for more details.
 
@@ -572,8 +572,8 @@ Draftail has a `focus()` API [like that of Draft.js](https://draftjs.org/docs/ad
 
 Draft.js and Draftail build upon ES6 language features. If targeting browsers that do not support them, have a look at:
 
-* [Draft.js required polyfills](https://facebook.github.io/draft-js/docs/advanced-topics-issues-and-pitfalls.html#polyfills).
-* [`position: sticky` support](https://caniuse.com/#feat=css-sticky), and [`stickyfill` polyfill](https://github.com/wilddeer/stickyfill).
+*   [Draft.js required polyfills](https://facebook.github.io/draft-js/docs/advanced-topics-issues-and-pitfalls.html#polyfills).
+*   [`position: sticky` support](https://caniuse.com/#feat=css-sticky), and [`stickyfill` polyfill](https://github.com/wilddeer/stickyfill).
 
 The Draftail demo site lists minimum polyfills for IE11 support: [`examples/utils/polyfills.js`](examples/utils/polyfills.js).
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Optionally, entities can also take an `attributes` and `whitelist` props. These 
 
 ##### Sources
 
-Sources are responsible for creating and editing entities, and are toggled when requested from the toolbar, or from a decorator or block. Here is a [simple image source](https://github.com/springload/draftjs_exporter_demo/blob/master/src/entities/ImageSource.js) which uses `window.prompt` to ask the user for an image's `src`, then creates an entity and its atomic block:
+Sources are responsible for creating and editing entities, and are toggled when requested from the toolbar, or from a decorator or block. Here is a [simple image source](https://github.com/thibaudcolas/draftail-playground/blob/master/src/entities/ImageSource.js) which uses `window.prompt` to ask the user for an image's `src`, then creates an entity and its atomic block:
 
 ```js
 import { Component } from 'react';
@@ -426,7 +426,7 @@ The `onEdit` and `onRemove` props are meant so decorators can also serve in mana
 
 ##### Blocks
 
-Blocks render block-level entities based on their data, and can contain editing controls. Here is a [simple image block](https://github.com/springload/draftjs_exporter_demo/blob/master/src/entities/ImageBlock.js), rendering images with `src` and `alt` attributes:
+Blocks render block-level entities based on their data, and can contain editing controls. Here is a [simple image block](https://github.com/thibaudcolas/draftail-playground/blob/master/src/entities/ImageBlock.js), rendering images with `src` and `alt` attributes:
 
 ```jsx
 import React, { Component } from 'react';

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,103 @@
+const path = require('path');
+const { danger, message, warn, fail, schedule } = require('danger');
+const jest = require('danger-plugin-jest').default;
+
+const libModifiedFiles = danger.git.modified_files.filter(
+    filepath => filepath.startsWith('lib') && filepath.endsWith('js'),
+);
+const hasLibChanges =
+    libModifiedFiles.filter(filepath => !filepath.endsWith('test.js')).length >
+    0;
+const hasREADMEChanges = danger.git.modified_files.includes('README.md');
+const hasCHANGELOGChanges = danger.git.modified_files.includes('CHANGELOG.md');
+const hasUserguideChanges = danger.git.modified_files.some(filepath =>
+    filepath.includes('docs/user-guide'),
+);
+
+// Fails if the description is too short.
+if (!danger.github.pr.body || danger.github.pr.body.length < 10) {
+    fail(':grey_question: This pull request needs a description.');
+}
+
+// Warns if the PR title contains [WIP]
+const isWIP = danger.github.pr.title.includes('WIP');
+if (isWIP) {
+    const title = ':construction_worker: Work In Progress';
+    const idea =
+        'This PR appears to be a work in progress, and may not be ready to be merged yet.';
+    warn(`${title} - <i>${idea}</i>`);
+}
+
+if (hasLibChanges && !(hasREADMEChanges || hasUserguideChanges)) {
+    warn(
+        'This pull request updates the library. Should the [API reference](https://github.com/springload/draftail/blob/master/README.md) be updated as well? The [User guide](https://github.com/springload/draftail/blob/master/docs/user-guide/README.md)?',
+    );
+}
+
+const hasLabels = danger.github.issue.labels.length !== 0;
+const isEnhancement =
+    danger.github.issue.labels.some(l => l.name === 'enhancement') ||
+    danger.github.pr.title.includes('feature');
+const isBug =
+    danger.github.issue.labels.some(l => l.name === 'bug') ||
+    danger.github.pr.title.includes('fix') ||
+    danger.github.pr.title.includes('bug');
+
+if (!hasLabels) {
+    message('What labels should we add to this PR?');
+}
+
+if (hasLibChanges && isEnhancement && !hasCHANGELOGChanges) {
+    warn(
+        'This pull request is an enhancement. Please update the [CHANGELOG](https://github.com/springload/draftail/blob/master/CHANGELOG.md).',
+    );
+}
+
+if (hasLibChanges && isBug && !hasCHANGELOGChanges) {
+    fail(
+        'This pull request fixes a bug. Please update the [CHANGELOG](https://github.com/springload/draftail/blob/master/CHANGELOG.md).',
+    );
+}
+
+const hasPackageChanges = danger.git.modified_files.includes('package.json');
+const hasLockfileChanges = danger.git.modified_files.includes(
+    'package-lock.json',
+);
+
+if (hasPackageChanges && !hasLockfileChanges) {
+    warn(
+        'There are package.json changes with no corresponding lockfile changes.',
+    );
+}
+
+const linkDep = dep =>
+    danger.utils.href(`https://www.npmjs.com/package/${dep}`, dep);
+
+schedule(async () => {
+    const packageDiff = await danger.git.JSONDiffForFile('package.json');
+
+    if (packageDiff.dependencies) {
+        const added = packageDiff.dependencies.added;
+        const removed = packageDiff.dependencies.removed;
+
+        if (added.length) {
+            const deps = danger.utils.sentence(added.map(d => linkDep(d)));
+            message(`Adding new dependencies: ${deps}`);
+        }
+
+        if (removed.length) {
+            const deps = danger.utils.sentence(removed.map(d => linkDep(d)));
+            message(`:tada:, removing dependencies: ${deps}`);
+        }
+
+        if (added.includes('draft-js')) {
+            warn(
+                ':scream: this PR updates Draft.js! Please make sure to review the [upgrade considerations](https://github.com/springload/draftail/tree/master/docs#upgrade-considerations).',
+            );
+        }
+    }
+});
+
+jest({
+    testResultsJsonPath: path.resolve(__dirname, 'public/test-results.json'),
+});

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -8,19 +8,19 @@ In the interest of fostering an open and welcoming environment, we as contributo
 
 Examples of behavior that contributes to creating a positive environment include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+*   Using welcoming and inclusive language
+*   Being respectful of differing viewpoints and experiences
+*   Gracefully accepting constructive criticism
+*   Focusing on what is best for the community
+*   Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+*   The use of sexualized language or imagery and unwelcome sexual attention or advances
+*   Trolling, insulting/derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or electronic address, without explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,11 @@
 
 ### Expected behavior
 
-* Pressing return on an empty list item should un-indent it until it is not nested, and then remove it.
-* Pressing return at the end of a block should create an empty unstyled block.
-* Atomic blocks (images, embeds, `hr`) are always preceded and followed by a block (empty if no other block is present). See [facebook/draft-js#327](https://github.com/facebook/draft-js/issues/327).
-* Blocks starting with "- ", "\* ", "1. " are automatically converted to list items.
-* Pasting content with block nesting above the configured maxium should reduce the depth up to the maximum.
+*   Pressing return on an empty list item should un-indent it until it is not nested, and then remove it.
+*   Pressing return at the end of a block should create an empty unstyled block.
+*   Atomic blocks (images, embeds, `hr`) are always preceded and followed by a block (empty if no other block is present). See [facebook/draft-js#327](https://github.com/facebook/draft-js/issues/327).
+*   Blocks starting with "- ", "\* ", "1. " are automatically converted to list items.
+*   Pasting content with block nesting above the configured maxium should reduce the depth up to the maximum.
 
 ## Upgrade considerations
 
@@ -22,19 +22,19 @@ When upgrading to a more recent Draft.js version, always review the full [CHANGE
 
 Here are specific parts of the code that **should always be reviewed before upgrading**, and may need to be updated, or that we may be able to remove:
 
-* https://github.com/springload/draftail/blob/df903f86c882bd5101eb05e152e8b8a8b9a4915e/lib/blocks/MediaBlock.js#L60-L71
-* https://github.com/springload/draftail/commit/431c3fd09c4cfc043c8b334544b05b9f580b75d2
-* https://github.com/springload/draftail/blob/df903f86c882bd5101eb05e152e8b8a8b9a4915e/lib/api/behavior.js#L100-L110
-* https://github.com/springload/draftail/blob/df903f86c882bd5101eb05e152e8b8a8b9a4915e/lib/api/behavior.js#L23:L26
-* https://github.com/springload/draftail/commit/162fc13e193ac581f662de393151efde477183b9
-* https://github.com/springload/draftail/commit/88ae9adcda1929c92f065655a03c1b33fcfe6c2d
-* https://github.com/springload/draftail/commit/e05df07f8ed6c5df65c79824bbb1dcd6e8800bdd
+*   https://github.com/springload/draftail/blob/df903f86c882bd5101eb05e152e8b8a8b9a4915e/lib/blocks/MediaBlock.js#L60-L71
+*   https://github.com/springload/draftail/commit/431c3fd09c4cfc043c8b334544b05b9f580b75d2
+*   https://github.com/springload/draftail/blob/df903f86c882bd5101eb05e152e8b8a8b9a4915e/lib/api/behavior.js#L100-L110
+*   https://github.com/springload/draftail/blob/df903f86c882bd5101eb05e152e8b8a8b9a4915e/lib/api/behavior.js#L23:L26
+*   https://github.com/springload/draftail/commit/162fc13e193ac581f662de393151efde477183b9
+*   https://github.com/springload/draftail/commit/88ae9adcda1929c92f065655a03c1b33fcfe6c2d
+*   https://github.com/springload/draftail/commit/e05df07f8ed6c5df65c79824bbb1dcd6e8800bdd
 
 ### Webpack
 
 We generally follow the configuration of [create-react-app](https://github.com/facebookincubator/create-react-app);
 
-* UglifyJS issues: https://github.com/springload/draftail/blob/df903f86c882bd5101eb05e152e8b8a8b9a4915e/webpack/webpack.config.prod.js#L15-L31
+*   UglifyJS issues: https://github.com/springload/draftail/blob/df903f86c882bd5101eb05e152e8b8a8b9a4915e/webpack/webpack.config.prod.js#L15-L31
 
 ## Demo site
 
@@ -52,4 +52,4 @@ To regenerate it, get the serialised ContentState for the index page's editor (i
 
 ## Troubleshooting
 
-* In Firefox, the [`dom.event.clipboardevents.enabled`](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/dom.event.clipboardevents.enabled) setting must be turned on, otherwise the editor will crash on copy-paste. This could be off in [Iceweasel](https://wiki.debian.org/Iceweasel). See [wagtail/wagtail#4346](https://github.com/wagtail/wagtail/issues/4346).
+*   In Firefox, the [`dom.event.clipboardevents.enabled`](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/dom.event.clipboardevents.enabled) setting must be turned on, otherwise the editor will crash on copy-paste. This could be off in [Iceweasel](https://wiki.debian.org/Iceweasel). See [wagtail/wagtail#4346](https://github.com/wagtail/wagtail/issues/4346).

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -11,15 +11,15 @@ One thing that sets Draftail apart from other editors is its configurability: **
 
 ## Contents
 
-* [Online demo](#online-demo)
-* [Browser support](#browser-support)
-* [The editor](#the-editor)
-  * [Using keyboard shortcuts](#using-keyboard-shortcuts)
-  * [Copy-pasting content in the editor](#copy-pasting-content-in-the-editor)
-* [Links, images, and more](#links-images-and-more)
-* [Feedback](#feedback)
-* [Keyboard shortcuts](#keyboard-shortcuts)
-* [Credits](#credits)
+*   [Online demo](#online-demo)
+*   [Browser support](#browser-support)
+*   [The editor](#the-editor)
+    *   [Using keyboard shortcuts](#using-keyboard-shortcuts)
+    *   [Copy-pasting content in the editor](#copy-pasting-content-in-the-editor)
+*   [Links, images, and more](#links-images-and-more)
+*   [Feedback](#feedback)
+*   [Keyboard shortcuts](#keyboard-shortcuts)
+*   [Credits](#credits)
 
 ## Online demo
 

--- a/docs/user-guide/fr_FR/README.md
+++ b/docs/user-guide/fr_FR/README.md
@@ -11,14 +11,14 @@ Une caractéristique qui distingue Draftail des autres éditeurs est sa configur
 
 ## Table des matières
 
-* [Démo en ligne](#d%C3%A9mo-en-ligne)
-* [Support des navigateurs](#support-des-navigateurs)
-* [L’éditeur](#l%C3%A9diteur)
-  * [Utiliser les raccourcis clavier](#utiliser-les-raccourcis-clavier)
-  * [Copier-coller du contenu dans l’éditeur](#copier-coller-du-contenu-dans-l%C3%A9diteur)
-* [Liens, images, et plus](#liens-images-et-plus)
-* [Feedback](#feedback)
-* [Raccourcis clavier](#raccourcis-clavier)
+*   [Démo en ligne](#d%C3%A9mo-en-ligne)
+*   [Support des navigateurs](#support-des-navigateurs)
+*   [L’éditeur](#l%C3%A9diteur)
+    *   [Utiliser les raccourcis clavier](#utiliser-les-raccourcis-clavier)
+    *   [Copier-coller du contenu dans l’éditeur](#copier-coller-du-contenu-dans-l%C3%A9diteur)
+*   [Liens, images, et plus](#liens-images-et-plus)
+*   [Feedback](#feedback)
+*   [Raccourcis clavier](#raccourcis-clavier)
 
 ## Démo en ligne
 

--- a/examples/blocks/MediaBlock.js
+++ b/examples/blocks/MediaBlock.js
@@ -83,9 +83,9 @@ class MediaBlock extends Component {
                 type="button"
                 tabIndex={-1}
                 className="MediaBlock"
-                aria-label={`${entityType.description}${label ? ': ' : ''}${
-                    label
-                }`}
+                aria-label={`${entityType.description}${
+                    label ? ': ' : ''
+                }${label}`}
                 onMouseUp={this.openTooltip}
             >
                 <span className="MediaBlock__icon-wrapper" aria-hidden>

--- a/examples/sources/EmbedSource.js
+++ b/examples/sources/EmbedSource.js
@@ -5,9 +5,7 @@ import { AtomicBlockUtils, EditorState } from 'draft-js';
 import Modal from '../components/Modal';
 
 /* global EMBEDLY_API_KEY */
-const EMBEDLY_ENDPOINT = `https://api.embedly.com/1/oembed?key=${
-    EMBEDLY_API_KEY
-}`;
+const EMBEDLY_ENDPOINT = `https://api.embedly.com/1/oembed?key=${EMBEDLY_API_KEY}`;
 
 const getJSON = (endpoint, data, successCallback) => {
     const request = new XMLHttpRequest();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10215,9 +10215,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
-      "integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
+      "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
       "dev": true
     },
     "pretty-error": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -477,29 +477,6 @@
         "ast-types-flow": "0.0.7"
       }
     },
-    "babel-cli": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
-      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.0",
-        "babel-polyfill": "6.26.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "chokidar": "1.7.0",
-        "commander": "2.11.0",
-        "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "v8flags": "2.1.1"
-      }
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -1171,25 +1148,6 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
-      }
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
-        }
       }
     },
     "babel-preset-env": {
@@ -4055,12 +4013,6 @@
         "jsonfile": "3.0.1",
         "universalify": "0.1.1"
       }
-    },
-    "fs-readdir-recursive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8214,17 +8166,6 @@
         "os-tmpdir": "1.0.2"
       }
     },
-    "output-file-sync": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -12292,12 +12233,6 @@
         }
       }
     },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-      "dev": true
-    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -12348,15 +12283,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
-    },
-    "v8flags": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true,
-      "requires": {
-        "user-home": "1.1.1"
-      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,49 @@
         "js-tokens": "3.0.2"
       }
     },
+    "@octokit/rest": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.6.1.tgz",
+      "integrity": "sha512-KpyRdr7ie62wTmc3NQEG7jKm7ke6VxHJvRby/dMKtdllrBtXZikigVAbXsqBSP/yMxpayE2f6AwsQfm4XnX1xw==",
+      "dev": true,
+      "requires": {
+        "before-after-hook": "1.1.0",
+        "btoa-lite": "1.0.0",
+        "debug": "3.1.0",
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.1",
+        "lodash": "4.17.4",
+        "node-fetch": "2.1.2",
+        "url-template": "2.0.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+          "dev": true,
+          "requires": {
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+          "dev": true
+        }
+      }
+    },
     "@types/node": {
       "version": "8.0.53",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
@@ -101,6 +144,13 @@
         }
       }
     },
+    "address": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
+      "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
+      "dev": true,
+      "optional": true
+    },
     "agent-base": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
@@ -148,6 +198,48 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
+    },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -218,6 +310,64 @@
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
+      }
+    },
+    "args": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/args/-/args-3.0.2.tgz",
+      "integrity": "sha1-hQu46IHzE5IDpeTLF2QxCStWLC0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "4.1.0",
+        "chalk": "1.1.3",
+        "minimist": "1.2.0",
+        "pkginfo": "0.4.0",
+        "string-similarity": "1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true,
+          "optional": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "aria-query": {
@@ -375,6 +525,17 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
+    },
+    "async-to-gen": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-to-gen/-/async-to-gen-1.3.3.tgz",
+      "integrity": "sha1-1SyftIAfDfRKvE0t4YcLSLYOILs=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "babylon": "6.18.0",
+        "magic-string": "0.19.1"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1150,6 +1311,25 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
@@ -1306,6 +1486,13 @@
       "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
       "dev": true
     },
+    "basic-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+      "dev": true,
+      "optional": true
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -1321,6 +1508,12 @@
       "requires": {
         "tweetnacl": "0.14.5"
       }
+    },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==",
+      "dev": true
     },
     "big.js": {
       "version": "3.1.3",
@@ -1390,6 +1583,87 @@
       "dev": true,
       "requires": {
         "hoek": "2.16.3"
+      }
+    },
+    "boxen": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
+      "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
+      "dev": true,
+      "requires": {
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "0.1.1",
+        "widest-line": "1.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -1531,6 +1805,12 @@
         "node-int64": "0.4.0"
       }
     },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+      "dev": true
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1541,6 +1821,12 @@
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "dev": true
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -1655,6 +1941,12 @@
       "version": "1.0.30000717",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000717.tgz",
       "integrity": "sha1-RTmxJq94fB1IUZRN4isr2HgNNhI=",
+      "dev": true
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
     "caseless": {
@@ -1793,6 +2085,12 @@
         "source-map": "0.5.7"
       }
     },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
+    },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -1818,6 +2116,46 @@
         "good-listener": "1.2.2",
         "select": "1.1.2",
         "tiny-emitter": "2.0.2"
+      }
+    },
+    "clipboardy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.1.4.tgz",
+      "integrity": "sha1-UbF1dPxoJYji3Slc+m5qoQnqte4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "execa": "0.6.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "execa": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
+          "integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        }
       }
     },
     "cliui": {
@@ -2051,6 +2389,20 @@
         "typedarray": "0.0.6"
       }
     },
+    "configstore": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.0.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
+      }
+    },
     "connect-history-api-fallback": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
@@ -2165,6 +2517,15 @@
         "elliptic": "6.4.0"
       }
     },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
+    },
     "create-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
@@ -2201,6 +2562,16 @@
         "which": "1.3.0"
       }
     },
+    "cross-spawn-async": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "which": "1.3.0"
+      }
+    },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -2228,6 +2599,12 @@
         "randombytes": "2.0.5",
         "randomfill": "1.0.3"
       }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -2530,6 +2907,171 @@
       "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
       "dev": true
     },
+    "danger": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/danger/-/danger-3.7.4.tgz",
+      "integrity": "sha512-6gUROa5hX1BDyDDxeRDMkX2OaNeqQNWwnE8YyN3vUch4T4dQfERhRD9gor7ZqzDnSkLFq9QWcfw6WlSbS9ELMg==",
+      "dev": true,
+      "requires": {
+        "@octokit/rest": "15.6.1",
+        "babel-polyfill": "6.26.0",
+        "chalk": "2.4.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "get-stdin": "6.0.0",
+        "hyperlinker": "1.0.0",
+        "jsome": "2.5.0",
+        "json5": "1.0.1",
+        "jsonpointer": "4.0.1",
+        "jsonwebtoken": "8.2.1",
+        "lodash.find": "4.6.0",
+        "lodash.includes": "4.3.0",
+        "lodash.isobject": "3.0.2",
+        "lodash.keys": "4.2.0",
+        "node-cleanup": "2.1.2",
+        "node-fetch": "2.1.2",
+        "p-limit": "1.2.0",
+        "parse-diff": "0.4.2",
+        "parse-git-config": "2.0.2",
+        "parse-github-url": "1.0.2",
+        "parse-link-header": "1.0.1",
+        "pinpoint": "1.1.0",
+        "readline-sync": "1.4.9",
+        "require-from-string": "2.0.2",
+        "rfc6902": "2.2.2",
+        "supports-hyperlinks": "1.0.1",
+        "vm2": "3.6.0",
+        "voca": "1.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+          "dev": true,
+          "requires": {
+            "p-try": "1.0.0"
+          }
+        },
+        "require-from-string": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+          "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "danger-plugin-jest": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/danger-plugin-jest/-/danger-plugin-jest-1.1.0.tgz",
+      "integrity": "sha1-m1PhSgSD5t5aZfjVj7tqgSGpSNQ=",
+      "dev": true,
+      "requires": {
+        "serve": "5.2.4",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "dargs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+      "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk=",
+      "dev": true,
+      "optional": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2572,6 +3114,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
       "dev": true
     },
     "deep-is": {
@@ -2681,6 +3229,17 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
       "dev": true
+    },
+    "detect-port": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.2.1.tgz",
+      "integrity": "sha512-2KWLTLsfpi/oYPGNBEniPcFzr1GW/s+Xq/4hJmTQRdE8ULuRwGnRPuVhS/cf+Z4ZEXNo7EO2f6oydHJQd94KMg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "address": "1.0.3",
+        "debug": "2.6.8"
+      }
     },
     "diff": {
       "version": "3.4.0",
@@ -2821,6 +3380,15 @@
         "domelementtype": "1.3.0"
       }
     },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
+    },
     "dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
@@ -2854,6 +3422,12 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -2862,6 +3436,15 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "ee-first": {
@@ -3622,6 +4205,15 @@
         "fill-range": "2.2.3"
       }
     },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1"
+      }
+    },
     "expect": {
       "version": "22.2.2",
       "resolved": "https://registry.npmjs.org/expect/-/expect-22.2.2.tgz",
@@ -3694,6 +4286,15 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1"
+      }
     },
     "extglob": {
       "version": "0.3.2",
@@ -4001,6 +4602,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
     },
     "fs-extra": {
@@ -4994,6 +5601,13 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
+    "get-port": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.1.0.tgz",
+      "integrity": "sha1-7wGxioTKZIaXD/meVERhQac//T4=",
+      "dev": true,
+      "optional": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -5021,6 +5635,17 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
+      }
+    },
+    "git-config-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+      "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "fs-exists-sync": "0.1.0",
+        "homedir-polyfill": "1.0.1"
       }
     },
     "glob": {
@@ -5114,6 +5739,25 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
+      }
+    },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -5282,6 +5926,15 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -5437,6 +6090,27 @@
         "requires-port": "1.0.0"
       }
     },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "http-proxy-middleware": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
@@ -5504,6 +6178,12 @@
         }
       }
     },
+    "hyperlinker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
+      "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
@@ -5542,6 +6222,13 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
       "dev": true
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true,
+      "optional": true
     },
     "import-local": {
       "version": "1.0.0",
@@ -5600,6 +6287,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -5703,6 +6396,13 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "is-async-supported": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-async-supported/-/is-async-supported-1.2.0.tgz",
+      "integrity": "sha1-INWKxNZwfrHLNxLdOEgMBTbyfAc=",
+      "dev": true,
+      "optional": true
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -5833,6 +6533,12 @@
         "xtend": "4.0.1"
       }
     },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -5841,6 +6547,12 @@
       "requires": {
         "kind-of": "3.2.2"
       }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -5907,6 +6619,12 @@
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -5924,6 +6642,12 @@
       "requires": {
         "tryit": "1.0.3"
       }
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -5963,6 +6687,13 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true,
+      "optional": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -7058,6 +7789,148 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
+    "jsome": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jsome/-/jsome-2.5.0.tgz",
+      "integrity": "sha1-XkF+70NB/+uD7ov6kmWzbVb+Se0=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "json-stringify-safe": "5.0.1",
+        "yargs": "11.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
@@ -7124,6 +7997,32 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+      "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
+      "dev": true,
+      "requires": {
+        "jws": "3.1.5",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -7150,6 +8049,27 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "jwa": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "dev": true,
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "dev": true,
+      "requires": {
+        "jwa": "1.1.6",
+        "safe-buffer": "5.1.1"
+      }
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -7159,11 +8079,27 @@
         "is-buffer": "1.1.5"
       }
     },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "4.0.1"
+      }
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
+    },
+    "lazy-req": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz",
+      "integrity": "sha1-yUUKNj7N2i5vDHATKtTzf48G8rQ=",
+      "dev": true,
+      "optional": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -7266,10 +8202,64 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+      "dev": true
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+      "dev": true
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "dev": true
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "dev": true
+    },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=",
       "dev": true
     },
     "lodash.memoize": {
@@ -7288,6 +8278,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
+      "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
     "lodash.sortby": {
@@ -7345,6 +8341,12 @@
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -7360,6 +8362,16 @@
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
+    },
+    "magic-string": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.19.1.tgz",
+      "integrity": "sha1-FNdoATyvLsj96hakmvgvw3fnUgE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "vlq": "0.2.3"
+      }
     },
     "make-dir": {
       "version": "1.0.0",
@@ -7490,6 +8502,156 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
+    },
+    "micro": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/micro/-/micro-7.3.3.tgz",
+      "integrity": "sha1-gmHFbSoxp9+TmG7/hkQTlvK0sHA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "args": "2.6.1",
+        "async-to-gen": "1.3.3",
+        "bluebird": "3.5.0",
+        "boxen": "1.1.0",
+        "chalk": "1.1.3",
+        "clipboardy": "1.1.1",
+        "get-port": "3.1.0",
+        "ip": "1.1.5",
+        "is-async-supported": "1.2.0",
+        "isstream": "0.1.2",
+        "media-typer": "0.3.0",
+        "node-version": "1.0.0",
+        "raw-body": "2.2.0",
+        "update-notifier": "2.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "args": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/args/-/args-2.6.1.tgz",
+          "integrity": "sha1-slkO1BaM0xtiREGZvcUWa7GSDC8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "chalk": "1.1.3",
+            "minimist": "1.2.0",
+            "pkginfo": "0.4.0",
+            "string-similarity": "1.1.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "dev": true,
+          "optional": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "clipboardy": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.1.1.tgz",
+          "integrity": "sha1-dbWnrFDYPJgCX7YwMpjGqQB8Fsc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "execa": "0.6.3"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "execa": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
+          "integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "update-notifier": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
+          "integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boxen": "1.1.0",
+            "chalk": "1.1.3",
+            "configstore": "3.1.2",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "lazy-req": "2.0.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          }
+        }
+      }
+    },
+    "micro-compress": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micro-compress/-/micro-compress-1.0.0.tgz",
+      "integrity": "sha1-U/WoC0rQMgyhZaVZtuPfFF1PcE8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "compression": "1.7.1"
+      }
     },
     "micromatch": {
       "version": "2.3.11",
@@ -7678,6 +8840,12 @@
         "lower-case": "1.1.4"
       }
     },
+    "node-cleanup": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
+      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
+      "dev": true
+    },
     "node-fetch": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
@@ -7824,6 +8992,12 @@
           "dev": true
         }
       }
+    },
+    "node-version": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.0.0.tgz",
+      "integrity": "sha1-G5uVhKmn96YSPyFc0UplK/IasZ4=",
+      "dev": true
     },
     "nomnom": {
       "version": "1.6.2",
@@ -8193,6 +9367,24 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.4.1"
+      }
+    },
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
@@ -8221,6 +9413,29 @@
         "pbkdf2": "3.0.14"
       }
     },
+    "parse-diff": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.4.2.tgz",
+      "integrity": "sha512-YYQzII66NqysdPgDVxzbdwNXMv5Ww562JSZSXZ4RIPoolzD7yqA4crgD8swrs+JNcvjoZMKMiT4kGcLYvf6IoA==",
+      "dev": true
+    },
+    "parse-git-config": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-2.0.2.tgz",
+      "integrity": "sha512-ObBoF8oac1DKo78J6R+O9KwhMNL0yCmizi4/WKyB6rQXNHe4SmLMhnLrpPogWT2BbJUx1LcIzec/ftAiveSVhQ==",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "git-config-path": "1.0.1",
+        "ini": "1.3.5"
+      }
+    },
+    "parse-github-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
+      "dev": true
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -8241,6 +9456,21 @@
       "requires": {
         "error-ex": "1.3.1"
       }
+    },
+    "parse-link-header": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
+      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "dev": true,
+      "requires": {
+        "xtend": "4.0.1"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parse5": {
       "version": "4.0.0",
@@ -8353,6 +9583,12 @@
         "pinkie": "2.0.4"
       }
     },
+    "pinpoint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
+      "integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
+      "dev": true
+    },
     "pixelmatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
@@ -8370,6 +9606,12 @@
       "requires": {
         "find-up": "2.1.0"
       }
+    },
+    "pkginfo": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
+      "integrity": "sha1-NJ27f/04CB/K3AhT32h/DHdEzWU=",
+      "dev": true
     },
     "pluralize": {
       "version": "1.2.1",
@@ -10522,6 +11764,54 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
+    "raw-body": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+          "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+          "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.5.1",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "react": {
       "version": "16.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-16.1.1.tgz",
@@ -10642,6 +11932,12 @@
       "integrity": "sha1-sKE8uFEfXqpXDPEE0boNaNUKpHE=",
       "dev": true
     },
+    "readline-sync": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
+      "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No=",
+      "dev": true
+    },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
@@ -10759,6 +12055,25 @@
         "regenerate": "1.3.2",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.7",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.7"
       }
     },
     "regjsgen": {
@@ -11041,6 +12356,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "rfc6902": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-2.2.2.tgz",
+      "integrity": "sha512-/5JHC6Kr7EJnivq9M5O3WGnHBs5yCBJeQHB75IsBPPHDyaiuf0jsaQ4g0ehd5N+xPddPKGJH7rzp2AbaQdve3w==",
+      "dev": true
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -11278,6 +12599,15 @@
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "5.4.1"
+      }
+    },
     "send": {
       "version": "0.15.6",
       "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
@@ -11307,6 +12637,178 @@
           "requires": {
             "ms": "2.0.0"
           }
+        }
+      }
+    },
+    "serve": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-5.2.4.tgz",
+      "integrity": "sha1-R0LAX2WiMw94jN3pAc16CbI6mfY=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "args": "3.0.2",
+        "basic-auth": "1.1.0",
+        "bluebird": "3.5.0",
+        "boxen": "1.1.0",
+        "chalk": "1.1.3",
+        "clipboardy": "1.1.4",
+        "dargs": "5.1.0",
+        "detect-port": "1.2.1",
+        "filesize": "3.5.10",
+        "fs-extra": "3.0.1",
+        "handlebars": "4.0.10",
+        "ip": "1.1.5",
+        "micro": "7.3.3",
+        "micro-compress": "1.0.0",
+        "mime-types": "2.1.15",
+        "node-version": "1.0.0",
+        "opn": "5.1.0",
+        "path-type": "2.0.0",
+        "send": "0.15.3",
+        "update-notifier": "2.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true,
+          "optional": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true,
+          "optional": true
+        },
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "fresh": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+          "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+          "dev": true,
+          "optional": true
+        },
+        "handlebars": {
+          "version": "4.0.10",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "dev": true,
+          "optional": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "opn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
+          "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-wsl": "1.1.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "send": {
+          "version": "0.15.3",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
+          "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.7",
+            "depd": "1.1.1",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.0",
+            "http-errors": "1.6.2",
+            "mime": "1.3.4",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11727,6 +13229,15 @@
         }
       }
     },
+    "string-similarity": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-1.1.0.tgz",
+      "integrity": "sha1-PGZJiFikZex8QMfYFzm72ZWQSRQ=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -11799,6 +13310,35 @@
       "dev": true,
       "requires": {
         "has-flag": "2.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+      "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "svgo": {
@@ -11913,6 +13453,46 @@
         "inherits": "2.0.3"
       }
     },
+    "term-size": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
+      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
+      "dev": true,
+      "requires": {
+        "execa": "0.4.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+          "dev": true,
+          "requires": {
+            "cross-spawn-async": "2.2.5",
+            "is-stream": "1.1.0",
+            "npm-run-path": "1.0.0",
+            "object-assign": "4.1.1",
+            "path-key": "1.0.0",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+          "dev": true,
+          "requires": {
+            "path-key": "1.0.0"
+          }
+        },
+        "path-key": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
+          "dev": true
+        }
+      }
+    },
     "test-exclude": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
@@ -11964,6 +13544,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
       "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
+      "dev": true
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
     "timers-browserify": {
@@ -12179,6 +13765,15 @@
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "1.0.0"
+      }
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -12190,6 +13785,59 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
+      "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "boxen": "1.1.0",
+        "chalk": "1.1.3",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "upper-case": {
       "version": "1.1.3",
@@ -12232,6 +13880,21 @@
           "dev": true
         }
       }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
     },
     "util": {
       "version": "0.10.3",
@@ -12347,6 +14010,13 @@
         }
       }
     },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true,
+      "optional": true
+    },
     "vm-browserify": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
@@ -12355,6 +14025,18 @@
       "requires": {
         "indexof": "0.0.1"
       }
+    },
+    "vm2": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.6.0.tgz",
+      "integrity": "sha512-NPfqWC4QZ5NizUpzCFYrnZlx63G5+DB19wenQNjWUP4/7SOkBQpTWIb1upnL6SZw8yhaAyQFXHc3U223MJme4w==",
+      "dev": true
+    },
+    "voca": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/voca/-/voca-1.4.0.tgz",
+      "integrity": "sha512-8Xz4H3vhYRGbFupLtl6dHwMx0ojUcjt0HYkqZ9oBCfipd/5mD7Md58m2/dq7uPuZU/0T3Gb1m66KS9jn+I+14Q==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.1",
@@ -12946,6 +14628,15 @@
         "string-width": "1.0.2"
       }
     },
+    "widest-line": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -13011,6 +14702,12 @@
           "dev": true
         }
       }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
     },
     "xml-char-classes": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "node-sass": "^4.5.3",
     "normalize.css": "^7.0.0",
     "postcss-loader": "^2.0.6",
-    "prettier": "^1.8.2",
+    "prettier": "^1.12.1",
     "prismjs": "^1.8.4",
     "prop-types": "^15.6.0",
     "puppeteer": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,8 @@
     "babel-preset-react": "^6.24.1",
     "core-js": "^2.5.1",
     "css-loader": "^0.28.4",
+    "danger": "^3.7.4",
+    "danger-plugin-jest": "^1.1.0",
     "dotenv": "^4.0.0",
     "draft-js": "0.10.5",
     "enzyme": "^3.2.0",
@@ -165,12 +167,13 @@
     "build:webpack": "webpack --config=webpack/webpack.config.prod.js --display-optimization-bailout",
     "build": "npm run build:rollup -s && npm run build:autotrack -s && npm run build:webpack -s && cp public/draftail.css dist",
     "dist": "NODE_ENV=production npm run build -s",
+    "danger": "danger ci --verbose",
     "linter:js": "eslint",
     "linter:css": "prettier --list-different",
     "linter:md": "prettier --list-different",
     "formatter": "prettier --write",
     "lint": "npm run linter:js -s -- . && npm run linter:css -s -- '**/*.scss' && npm run linter:md -s -- '**/*.md'",
-    "format": "npm run formatter -s -- '**/*.scss' '**/*.md' lib/**/*.js examples/**/*.js webpack/*.js",
+    "format": "npm run formatter -s -- '**/*.{scss,md,js}'",
     "test": "jest",
     "test:integration": "jest --config tests/integration/jest.config.js",
     "test:integration:watch": "jest --config tests/integration/jest.config.js --watch",
@@ -180,7 +183,7 @@
     "report:coverage": "open coverage/lcov-report/index.html",
     "report:build": "open webpack/webpack-stats.html",
     "report:size": "uglifyjs --compress --mangle -- dist/draftail.cjs.js > dist/draftail.cjs.min.js && gzip --keep dist/* && wc -c dist/* && rm dist/*.gz",
-    "test:ci": "npm run lint -s && npm run test:coverage -s && npm run dist -s && npm run test:integration -s",
+    "test:ci": "npm run lint -s && npm run test:coverage -s -- --outputFile public/test-results.json --json && npm run dist -s && npm run test:integration -s",
     "prepublishOnly": "npm run dist -s"
   }
 }

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "test:watch:coverage": "jest --watch --coverage",
     "report:coverage": "open coverage/lcov-report/index.html",
     "report:build": "open webpack/webpack-stats.html",
+    "report:size": "uglifyjs --compress --mangle -- dist/draftail.cjs.js > dist/draftail.cjs.min.js && gzip --keep dist/* && wc -c dist/* && rm dist/*.gz",
     "test:ci": "npm run lint -s && npm run test:coverage -s && npm run dist -s && npm run test:integration -s",
     "prepublishOnly": "npm run dist -s"
   }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
   "devDependencies": {
     "autoprefixer": "^7.1.2",
     "autotrack": "^2.4.1",
-    "babel-cli": "^6.24.1",
     "babel-jest": "^22.2.2",
     "babel-loader": "^7.1.1",
     "babel-plugin-external-helpers": "^6.22.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,6 @@
 module.exports = Object.assign(
     {
-        proseWrap: false,
+        proseWrap: 'preserve',
     },
     // Use the Prettier config that comes with eslint-plugin-springload.
     require('eslint-plugin-springload/prettier.config'),


### PR DESCRIPTION
This contains various improvements to the project's tooling. Mainly:

- Adding a new `report:size` command to track bundle size in CI. I used this command locally before, it will be more useful if the results are tracked and visible over time.
- Adds [Danger](http://danger.systems/js/) to the project, along with @thi-bot. Twice as many Tails 🎉. It's proved really useful on other projects (eg. https://github.com/thibaudcolas/draftjs-filters/pull/11), so it's nice to have it here too.