### PR TITLE
Release v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,12 @@
 
 ## Unreleased
 
-### Added
-
-*   Add Draft.js copy-paste handling overrides from `draftjs-conductor`. This makes Draftail always preserve the full content as-is when copy-pasting between editors. Fix [#147](https://github.com/springload/draftail/issues/147) ([thibaudcolas/draftjs-conductor#2](https://github.com/thibaudcolas/draftjs-conductor/pull/2)).
+## [[v0.17.2]](https://github.com/springload/draftail/releases/tag/v0.17.2)
 
 ### Changed
 
 *   Update to `draftjs-filters@1.0.0`. This does not include any functional changes, but will cause a duplicated dependency for projects having both `draftail` and `draftjs-filters` as deps if they don’t also update `draftjs-filters`.
+*   Add Draft.js copy-paste handling overrides from `draftjs-conductor`. This makes Draftail always preserve the full content as-is when copy-pasting between editors. Fix [#147](https://github.com/springload/draftail/issues/147) ([thibaudcolas/draftjs-conductor#2](https://github.com/thibaudcolas/draftjs-conductor/pull/2)).
 
 ## [[v0.17.1]](https://github.com/springload/draftail/releases/tag/v0.17.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "draftail",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draftail",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "📝🍸 A configurable rich text editor based on Draft.js, built for Wagtail",
   "author": "Springload",
   "license": "MIT",


### PR DESCRIPTION
 *   Update to `draftjs-filters@1.0.0`. This does not include any functional changes, but will cause a duplicated dependency for projects having both `draftail` and `draftjs-filters` as deps if they don’t also update `draftjs-filters`.
+*   Add Draft.js copy-paste handling overrides from `draftjs-conductor`. This makes Draftail always preserve the full content as-is when copy-pasting between editors. Fix [#147](https://github.com/springload/draftail/issues/147) ([thibaudcolas/draftjs-conductor#2](https://github.com/thibaudcolas/draftjs-conductor/pull/2)).