### PR TITLE
Release v1.0.0. Fix #154

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+## [[v1.0.0]](https://github.com/springload/draftail/releases/tag/v1.0.0)
+
+> This release is functionally identical to the last one, `v0.17.2`.
+
+The project has reached a high-enough level of stability to be used in production, and breaking changes will now be reflected via major version changes.
+
 ## [[v0.17.2]](https://github.com/springload/draftail/releases/tag/v0.17.2)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "draftail",
-  "version": "0.17.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draftail",
-  "version": "0.17.2",
+  "version": "1.0.0",
   "description": "📝🍸 A configurable rich text editor based on Draft.js, built for Wagtail",
   "author": "Springload",
   "license": "MIT",


### PR DESCRIPTION
🎉. Closes #154, and completes the [v1.0.0 milestone](https://github.com/springload/draftail/issues?q=is%3Aopen+is%3Aissue+milestone%3Av1.0.0)

I didn't add the `stripPastedStyles` breaking change (https://github.com/springload/draftail/issues/154#issuecomment-394199811). I think it'd be better to do this at some stage, but there are no other breaking changes in this release so it feels like it would create unnecessary work to do this now.