### PR TITLE
Update draftjs-filters to latest, fixing paste filtering crash. Fix #179

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 ### Fixed
 
 - Stop unnecessarily calling `onSave` in the editor’s `onBlur` ([#173](https://github.com/springload/draftail/issues/173)).
+- Prevent crash when filtering pasted content whose last block is to be removed (e.g. unsupported image) ([#179](https://github.com/springload/draftail/issues/179)).
+
+### Changed
+
+- Update [`draftjs-filters`](https://github.com/thibaudcolas/draftjs-filters) dependency to v2.2.1 ([#179](https://github.com/springload/draftail/issues/179)).
 
 ## [[v1.0.0]](https://github.com/springload/draftail/releases/tag/v1.0.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6077,9 +6077,9 @@
       "integrity": "sha512-oazG/8otKjTZ1OdAA0BDaYiRsi4tJd0UmNjtIFebaqWUryyr76JyA2j/trFejEHQuNnSHjjeci4s9Jn4sxXPEA=="
     },
     "draftjs-filters": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/draftjs-filters/-/draftjs-filters-1.0.0.tgz",
-      "integrity": "sha512-OUXPZs/tYqge4BzPjA2+kiB0xcqxh4afPXq7c23YfRNrZM/tzRf8Ft2CXxOxR4j17xdBadD0qO0DXii0xFm6Rg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/draftjs-filters/-/draftjs-filters-2.2.1.tgz",
+      "integrity": "sha512-O1vWQyf0p599131JcMFF5uN5zM3lxf9tj5fIUqkJO7C4aBFS0GDuRoO68tJigtfhdhwhLjwwrsQfQdjTd17hwA=="
     },
     "duplexer": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "draftjs-conductor": "^0.2.1",
-    "draftjs-filters": "^1.0.0"
+    "draftjs-filters": "^2.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",


### PR DESCRIPTION
This updates https://github.com/thibaudcolas/draftjs-filters to its latest version, including https://github.com/thibaudcolas/draftjs-filters/issues/27 which fixes #179.

Input document: [draftail-crash-elon-musk-article.docx](https://github.com/thibaudcolas/draftjs-filters/files/2746243/draftail-crash-elon-musk-article.docx)

Repro:

1. Open the input document linked above with Word (might also work with other word processors).
2. Copy the content around the image
3. Paste in the editor

Now, the image should be absent and the selection should be on the block preceding it.