### PR TITLE
Upgrade Draft.js devDependency to v0.11.0 beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6092,14 +6092,38 @@
       }
     },
     "draft-js": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.10.5.tgz",
-      "integrity": "sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==",
+      "version": "0.11.0-beta",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.0-beta.tgz",
+      "integrity": "sha512-mamN/O5GCB1nUyOwDBlaQs3yopV/81O+a7bcVVwWqyuzjA3Q2rXODo5KQxBKhstDcggC14u7oigHVQUkwLaXgw==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.15",
+        "fbjs": "^1.0.0",
         "immutable": "~3.7.4",
         "object-assign": "^4.1.0"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.19",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+          "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
+          "dev": true
+        }
       }
     },
     "draftjs-conductor": {
@@ -7748,6 +7772,12 @@
           "dev": true
         }
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
     },
     "fd-slicer": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "danger": "^4.0.2",
     "dotenv": "^6.0.0",
     "draft-convert": "^2.1.4",
-    "draft-js": "0.10.5",
+    "draft-js": "^0.11.0-beta",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.6.0",
     "enzyme-to-json": "^3.3.4",


### PR DESCRIPTION
See https://github.com/facebook/draft-js/issues/2010. Full changelog (commits): https://github.com/facebook/draft-js/compare/v0.10.5...0.11.0-beta

TODO:

- [ ] Review [all commits](https://github.com/facebook/draft-js/compare/v0.10.5...0.11.0-beta)
- [ ] Manual test plan
- [ ] Updates to `draftjs-filters` and `draftjs-conductor`