### PR TITLE
Add Markdown-style shortcuts for inline formats (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This new API makes it possible to build much more advanced extensions to the edi
 - Add data reset parameter to `DraftUtils.resetBlockWithType()`.
 - Add ability to disable or customise the editor toolbar with [`topToolbar`](https://www.draftail.org/docs/customising-toolbars).
 - Add ability to add a toolbar below the editor with [`bottomToolbar`](https://www.draftail.org/docs/customising-toolbars).
+- Add support for Markdown shortcuts for inline styles, e.g. `**` for bold, `_` for italic, etc ([#134](https://github.com/springload/draftail/issues/134), [#187](https://github.com/springload/draftail/pull/187)). View the full list of [keyboard shortcuts](https://www.draftail.org/docs/keyboard-shortcuts).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here are important features worth highlighting:
 - Support for [keyboard shortcuts](https://www.draftail.org/docs/keyboard-shortcuts). Lots of them!
 - Paste from Word. Or any other editor. It just works.
 - Autolists – start a line with `-` , `*` , `1.` to create a list item.
-- Shortcuts for heading levels `##`, code blocks ` ``` `, and more.
+- Shortcuts for heading levels `##`, code blocks ` ``` `, text formats `**`, and more.
 - Undo / redo – until the end of times.
 - Common text types: headings, paragraphs, quotes, lists.
 - Common text styles: Bold, italic, and many more.

--- a/lib/api/DraftUtils.js
+++ b/lib/api/DraftUtils.js
@@ -188,59 +188,52 @@ export default {
     );
   },
 
+  /**
+   * Applies an inline style on a given range, based on a Markdown shortcut,
+   * removing the Markdown markers.
+   * Supports adding styles on existing styles, and entities.
+   */
   applyMarkdownStyle(
     editorState: EditorState,
     range: {|
       pattern: string,
       start: number,
       end: number,
-      length: number,
       type: string,
     |},
-    text: string,
     char: string,
   ) {
     const selection = editorState.getSelection();
-    let newContent = editorState.getCurrentContent();
+    let content = editorState.getCurrentContent();
 
-    newContent = Modifier.applyInlineStyle(
-      newContent,
-      selection.merge({
-        anchorOffset: range.start,
-        focusOffset: range.end,
-      }),
-      range.type,
-    );
+    const marked = selection.merge({
+      anchorOffset: range.start,
+      focusOffset: range.end,
+    });
+    const endMarker = selection.merge({
+      anchorOffset: range.end - range.pattern.length,
+      focusOffset: range.end,
+    });
+    const startMarker = selection.merge({
+      anchorOffset: range.start,
+      focusOffset: range.start + range.pattern.length,
+    });
 
-    newContent = Modifier.removeRange(
-      newContent,
-      selection.merge({
-        anchorOffset: range.end - range.pattern.length,
-        focusOffset: range.end,
-      }),
-      "forward",
-    );
-    newContent = Modifier.removeRange(
-      newContent,
-      selection.merge({
-        anchorOffset: range.start,
-        focusOffset: range.start + range.pattern.length,
-      }),
-      "forward",
-    );
+    // Remove the markers separately to preserve existing styles and entities on the marked text.
+    content = Modifier.applyInlineStyle(content, marked, range.type);
+    content = Modifier.removeRange(content, endMarker, "forward");
+    content = Modifier.removeRange(content, startMarker, "forward");
 
     const offset = selection.getFocusOffset() - range.pattern.length * 2;
     const endSelection = selection.merge({
       anchorOffset: offset,
       focusOffset: offset,
     });
-    newContent = newContent.merge({
-      selectionAfter: endSelection,
-    });
+    content = content.merge({ selectionAfter: endSelection });
 
-    newContent = Modifier.insertText(newContent, endSelection, char);
+    content = Modifier.insertText(content, endSelection, char);
 
-    return EditorState.push(editorState, newContent, "change-inline-style");
+    return EditorState.push(editorState, content, "change-inline-style");
   },
 
   /**

--- a/lib/api/DraftUtils.js
+++ b/lib/api/DraftUtils.js
@@ -188,6 +188,50 @@ export default {
     );
   },
 
+  applyMarkdownStyle(
+    editorState: EditorState,
+    range: {|
+      pattern: string,
+      start: number,
+      end: number,
+      length: number,
+      type: string,
+    |},
+    text: string,
+    char: string,
+  ) {
+    const selection = editorState.getSelection();
+    let newContent = editorState.getCurrentContent();
+
+    let target = selection.merge({
+      anchorOffset: range.start,
+      focusOffset: range.end,
+    });
+    newContent = Modifier.replaceText(
+      newContent,
+      target,
+      text
+        .slice(range.start, range.end)
+        .replace(range.pattern, "")
+        .replace(range.pattern, "") + char,
+    );
+    target = target.merge({
+      focusOffset: range.end - range.pattern.length * 2,
+    });
+
+    newContent = Modifier.applyInlineStyle(newContent, target, range.type);
+
+    const endSelection = target.merge({
+      anchorOffset: target.getFocusOffset() + 1,
+      focusOffset: target.getFocusOffset() + 1,
+    });
+    newContent = newContent.merge({
+      selectionAfter: endSelection,
+    });
+
+    return EditorState.push(editorState, newContent, "change-inline-style");
+  },
+
   /**
    * Removes the block at the given key.
    */

--- a/lib/api/DraftUtils.js
+++ b/lib/api/DraftUtils.js
@@ -203,31 +203,42 @@ export default {
     const selection = editorState.getSelection();
     let newContent = editorState.getCurrentContent();
 
-    let target = selection.merge({
-      anchorOffset: range.start,
-      focusOffset: range.end,
-    });
-    newContent = Modifier.replaceText(
+    newContent = Modifier.applyInlineStyle(
       newContent,
-      target,
-      text
-        .slice(range.start, range.end)
-        .replace(range.pattern, "")
-        .replace(range.pattern, "") + char,
+      selection.merge({
+        anchorOffset: range.start,
+        focusOffset: range.end,
+      }),
+      range.type,
     );
-    target = target.merge({
-      focusOffset: range.end - range.pattern.length * 2,
-    });
 
-    newContent = Modifier.applyInlineStyle(newContent, target, range.type);
+    newContent = Modifier.removeRange(
+      newContent,
+      selection.merge({
+        anchorOffset: range.end - range.pattern.length,
+        focusOffset: range.end,
+      }),
+      "forward",
+    );
+    newContent = Modifier.removeRange(
+      newContent,
+      selection.merge({
+        anchorOffset: range.start,
+        focusOffset: range.start + range.pattern.length,
+      }),
+      "forward",
+    );
 
-    const endSelection = target.merge({
-      anchorOffset: target.getFocusOffset() + 1,
-      focusOffset: target.getFocusOffset() + 1,
+    const offset = selection.getFocusOffset() - range.pattern.length * 2;
+    const endSelection = selection.merge({
+      anchorOffset: offset,
+      focusOffset: offset,
     });
     newContent = newContent.merge({
       selectionAfter: endSelection,
     });
+
+    newContent = Modifier.insertText(newContent, endSelection, char);
 
     return EditorState.push(editorState, newContent, "change-inline-style");
   },

--- a/lib/api/DraftUtils.test.js
+++ b/lib/api/DraftUtils.test.js
@@ -364,6 +364,141 @@ describe("DraftUtils", () => {
     });
   });
 
+  describe("#applyMarkdownStyle", () => {
+    it("works", () => {
+      let editorState = EditorState.createWithContent(
+        ContentState.createFromBlockArray(
+          convertFromHTML(`<p>This is a _Test_</p>`),
+        ),
+      );
+      editorState = EditorState.moveFocusToEnd(editorState);
+      editorState = DraftUtils.applyMarkdownStyle(
+        editorState,
+        {
+          start: 10,
+          end: 16,
+          pattern: "_",
+          type: "ITALIC",
+        },
+        "!",
+      );
+
+      expect(
+        convertToRaw(editorState.getCurrentContent()).blocks[0],
+      ).toMatchObject({
+        text: "This is a Test!",
+        inlineStyleRanges: [{ length: 4, offset: 10, style: "ITALIC" }],
+      });
+      expect(editorState.getSelection().toJS()).toMatchObject({
+        anchorOffset: 15,
+        focusOffset: 15,
+      });
+    });
+
+    it("stacks styles", () => {
+      let editorState = EditorState.createWithContent(
+        ContentState.createFromBlockArray(
+          convertFromHTML(`<p>This is a _<strong>Test</strong>_</p>`),
+        ),
+      );
+      editorState = EditorState.moveFocusToEnd(editorState);
+      editorState = DraftUtils.applyMarkdownStyle(
+        editorState,
+        {
+          start: 10,
+          end: 16,
+          pattern: "_",
+          type: "ITALIC",
+        },
+        "!",
+      );
+
+      expect(
+        convertToRaw(editorState.getCurrentContent()).blocks[0],
+      ).toMatchObject({
+        text: "This is a Test!",
+        inlineStyleRanges: [
+          { length: 4, offset: 10, style: "BOLD" },
+          { length: 4, offset: 10, style: "ITALIC" },
+        ],
+      });
+    });
+
+    it("respects entities", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {
+            "1": {
+              type: "LINK",
+              mutability: "MUTABLE",
+              data: {
+                url: "/test",
+              },
+            },
+          },
+          blocks: [
+            {
+              key: "a",
+              text: "A _test_",
+              entityRanges: [
+                {
+                  key: "1",
+                  offset: 3,
+                  length: 4,
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      editorState = EditorState.moveFocusToEnd(editorState);
+      editorState = DraftUtils.applyMarkdownStyle(
+        editorState,
+        {
+          start: 2,
+          end: 8,
+          pattern: "_",
+          type: "ITALIC",
+        },
+        "!",
+      );
+
+      expect(
+        convertToRaw(editorState.getCurrentContent()).blocks[0],
+      ).toMatchObject({
+        text: "A test!",
+        inlineStyleRanges: [{ length: 4, offset: 2, style: "ITALIC" }],
+        entityRanges: [{ length: 4, offset: 2 }],
+      });
+    });
+
+    it("supports arbitrary markers", () => {
+      let editorState = EditorState.createWithContent(
+        ContentState.createFromBlockArray(
+          convertFromHTML(`<p>A !!!test!!!</p>`),
+        ),
+      );
+      editorState = EditorState.moveFocusToEnd(editorState);
+      editorState = DraftUtils.applyMarkdownStyle(
+        editorState,
+        {
+          start: 2,
+          end: 12,
+          pattern: "!!!",
+          type: "CUSTOM",
+        },
+        "$",
+      );
+
+      expect(
+        convertToRaw(editorState.getCurrentContent()).blocks[0],
+      ).toMatchObject({
+        text: "A test$",
+        inlineStyleRanges: [{ length: 4, offset: 2, style: "CUSTOM" }],
+      });
+    });
+  });
+
   describe("#removeBlock", () => {
     it("works", () => {
       const editorState = DraftUtils.removeBlock(

--- a/lib/api/behavior.js
+++ b/lib/api/behavior.js
@@ -193,30 +193,23 @@ export default {
     input: string,
     inlineStyles: $ReadOnlyArray<{ type: string }>,
   ) {
-    const activeShortcuts = INPUT_STYLE_MAP.filter((shortcut) =>
-      inlineStyles.some((s) => s.type === shortcut[1]),
+    const activeShortcuts = INPUT_STYLE_MAP.filter(({ type }) =>
+      inlineStyles.some((s) => s.type === type),
     );
     let range;
 
-    const match = activeShortcuts.find(([pattern]) => {
-      const pat = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const char = pattern[0].replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      // https://regexper.com/#%28%5Cs%7C%5E%29__%28%5B%5E%5Cs_%5D%7B1%2C2%7D%7C%5B%5E%5Cs_%5D.%2B%5B%5E%5Cs_%5D%29__%24
-      const regex = new RegExp(
-        `(\\s|^)${pat}([^\\s${char}]{1,2}|[^\\s${char}].+[^\\s${char}])${pat}$`,
-        "g",
-      );
-      range = regex.exec(input);
+    const match = activeShortcuts.find(({ regex }) => {
+      range = new RegExp(regex, "g").exec(input);
 
       return range;
     });
 
     return range && match
       ? {
-          pattern: match[0],
+          pattern: match.pattern,
           start: range.index === 0 ? 0 : range.index + 1,
           end: range.index + range[0].length,
-          type: match[1],
+          type: match.type,
         }
       : false;
   },

--- a/lib/api/behavior.js
+++ b/lib/api/behavior.js
@@ -50,13 +50,11 @@ export default {
       });
     }
 
-    blockTypes
-      .filter((block) => block.element)
-      .forEach((block) => {
-        renderMap = renderMap.set(block.type, {
-          element: block.element,
-        });
+    blockTypes.filter((block) => block.element).forEach((block) => {
+      renderMap = renderMap.set(block.type, {
+        element: block.element,
       });
+    });
 
     return renderMap;
   },
@@ -193,8 +191,14 @@ export default {
     beforeInput: string,
     inlineStyles: $ReadOnlyArray<{ type: string }>,
   ) {
-    // TODO Explain
-    // https://github.com/mathiasbynens/esrever
+    const activeShortcuts = INPUT_STYLE_MAP.filter((shortcut) =>
+      inlineStyles.some((s) => s.type === shortcut[1]),
+    );
+
+    // This is so matching happens based on the Markdown shortcuts closest to the cursor, in case the text contains
+    // multiple shortcuts.
+    // This reversing ignores combining marks and astral symbols. This is fine, since shortcuts are ASCII-only.
+    // See https://github.com/mathiasbynens/esrever for further details.
     const input = beforeInput
       .split("")
       .reverse()
@@ -202,9 +206,7 @@ export default {
     let firstMatch;
     let secondMatch;
 
-    // TODO Make this less computation-intensive
-    const match = Object.keys(INPUT_STYLE_MAP).find((pattern) => {
-      const style = INPUT_STYLE_MAP[pattern];
+    const match = activeShortcuts.find(([pattern]) => {
       const regex = new RegExp(
         pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
         "g",
@@ -220,20 +222,19 @@ export default {
         // The first match is at the end of the text / start of reversed text.
         firstMatch.index === 0 &&
         // Second match is at the start of the text / end of reversed text, or preceded (followed) by whitespace.
-        // The second match is at index 0, or preceded by whitespace.
-        // This helps prevent patterns like “Use either `_privateMethod()`, or `_[...]” from matching.
+        // This helps prevent patterns like “Use either _privateMethod(), or _[...]” from matching.
         (secondMatch.index + pattern.length === input.length ||
-          /\s/.test(input[secondMatch.index + pattern.length])) &&
-        inlineStyles.some((s) => s.type === style)
+          /\s/.test(input[secondMatch.index + pattern.length]))
       );
     });
+
     return firstMatch && secondMatch && match
       ? {
-          pattern: match,
-          start: input.length - secondMatch.index - match.length,
+          pattern: match[0],
+          start: input.length - secondMatch.index - match[0].length,
           end: input.length - firstMatch.index,
-          length: secondMatch.index + match.length - firstMatch.index,
-          type: INPUT_STYLE_MAP[match],
+          length: secondMatch.index + match[0].length - firstMatch.index,
+          type: match[1],
         }
       : false;
   },

--- a/lib/api/behavior.js
+++ b/lib/api/behavior.js
@@ -16,6 +16,7 @@ import {
   KEYBOARD_SHORTCUTS,
   CUSTOM_STYLE_MAP,
   INPUT_BLOCK_MAP,
+  INPUT_STYLE_MAP,
   INPUT_ENTITY_MAP,
   INLINE_STYLE,
 } from "./constants";
@@ -186,6 +187,55 @@ export default {
       mark === INPUT_ENTITY_MAP[ENTITY_TYPE.HORIZONTAL_RULE] &&
       block.getType() !== BLOCK_TYPE.CODE
     );
+  },
+
+  handleBeforeInputInlineStyle(
+    beforeInput: string,
+    inlineStyles: $ReadOnlyArray<{ type: string }>,
+  ) {
+    // TODO Explain
+    // https://github.com/mathiasbynens/esrever
+    const input = beforeInput
+      .split("")
+      .reverse()
+      .join("");
+    let firstMatch;
+    let secondMatch;
+
+    // TODO Make this less computation-intensive
+    const match = Object.keys(INPUT_STYLE_MAP).find((pattern) => {
+      const style = INPUT_STYLE_MAP[pattern];
+      const regex = new RegExp(
+        pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+        "g",
+      );
+      firstMatch = regex.exec(input);
+      secondMatch = regex.exec(input);
+
+      return (
+        firstMatch &&
+        secondMatch &&
+        // The two matches aren't side by side.
+        firstMatch.index + pattern.length !== secondMatch.index &&
+        // The first match is at the end of the text / start of reversed text.
+        firstMatch.index === 0 &&
+        // Second match is at the start of the text / end of reversed text, or preceded (followed) by whitespace.
+        // The second match is at index 0, or preceded by whitespace.
+        // This helps prevent patterns like “Use either `_privateMethod()`, or `_[...]” from matching.
+        (secondMatch.index + pattern.length === input.length ||
+          /\s/.test(input[secondMatch.index + pattern.length])) &&
+        inlineStyles.some((s) => s.type === style)
+      );
+    });
+    return firstMatch && secondMatch && match
+      ? {
+          pattern: match,
+          start: input.length - secondMatch.index - match.length,
+          end: input.length - firstMatch.index,
+          length: secondMatch.index + match.length - firstMatch.index,
+          type: INPUT_STYLE_MAP[match],
+        }
+      : false;
   },
 
   getCustomStyleMap(

--- a/lib/api/behavior.js
+++ b/lib/api/behavior.js
@@ -50,11 +50,13 @@ export default {
       });
     }
 
-    blockTypes.filter((block) => block.element).forEach((block) => {
-      renderMap = renderMap.set(block.type, {
-        element: block.element,
+    blockTypes
+      .filter((block) => block.element)
+      .forEach((block) => {
+        renderMap = renderMap.set(block.type, {
+          element: block.element,
+        });
       });
-    });
 
     return renderMap;
   },
@@ -188,52 +190,33 @@ export default {
   },
 
   handleBeforeInputInlineStyle(
-    beforeInput: string,
+    input: string,
     inlineStyles: $ReadOnlyArray<{ type: string }>,
   ) {
     const activeShortcuts = INPUT_STYLE_MAP.filter((shortcut) =>
       inlineStyles.some((s) => s.type === shortcut[1]),
     );
-
-    // This is so matching happens based on the Markdown shortcuts closest to the cursor, in case the text contains
-    // multiple shortcuts.
-    // This reversing ignores combining marks and astral symbols. This is fine, since shortcuts are ASCII-only.
-    // See https://github.com/mathiasbynens/esrever for further details.
-    const input = beforeInput
-      .split("")
-      .reverse()
-      .join("");
-    let firstMatch;
-    let secondMatch;
+    let range;
 
     const match = activeShortcuts.find(([pattern]) => {
+      const pat = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const char = pattern[0].replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      // https://regexper.com/#%28%5Cs%7C%5E%29__%28%5B%5E%5Cs_%5D%7B1%2C2%7D%7C%5B%5E%5Cs_%5D.%2B%5B%5E%5Cs_%5D%29__%24
       const regex = new RegExp(
-        pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+        `(\\s|^)${pat}([^\\s${char}]{1,2}|[^\\s${char}].+[^\\s${char}])${pat}$`,
         "g",
       );
-      firstMatch = regex.exec(input);
-      secondMatch = regex.exec(input);
+      range = regex.exec(input);
 
-      return (
-        firstMatch &&
-        secondMatch &&
-        // The two matches aren't side by side.
-        firstMatch.index + pattern.length !== secondMatch.index &&
-        // The first match is at the end of the text / start of reversed text.
-        firstMatch.index === 0 &&
-        // Second match is at the start of the text / end of reversed text, or preceded (followed) by whitespace.
-        // This helps prevent patterns like “Use either _privateMethod(), or _[...]” from matching.
-        (secondMatch.index + pattern.length === input.length ||
-          /\s/.test(input[secondMatch.index + pattern.length]))
-      );
+      return range;
     });
 
-    return firstMatch && secondMatch && match
+    return range && match
       ? {
           pattern: match[0],
-          start: input.length - secondMatch.index - match[0].length,
-          end: input.length - firstMatch.index,
-          length: secondMatch.index + match[0].length - firstMatch.index,
+          start: range.index === 0 ? 0 : range.index + 1,
+          end: range.index + range[0].length,
+          length: range[0].length - 1,
           type: match[1],
         }
       : false;

--- a/lib/api/behavior.js
+++ b/lib/api/behavior.js
@@ -189,6 +189,10 @@ export default {
     );
   },
 
+  /**
+   * Checks whether a given input string contains style shortcuts.
+   * If so, returns the range onto which the shortcut is applied.
+   */
   handleBeforeInputInlineStyle(
     input: string,
     inlineStyles: $ReadOnlyArray<{ type: string }>,
@@ -199,6 +203,7 @@ export default {
     let range;
 
     const match = activeShortcuts.find(({ regex }) => {
+      // Re-create a RegExp object every time because RegExp is stateful.
       range = new RegExp(regex, "g").exec(input);
 
       return range;

--- a/lib/api/behavior.js
+++ b/lib/api/behavior.js
@@ -216,7 +216,6 @@ export default {
           pattern: match[0],
           start: range.index === 0 ? 0 : range.index + 1,
           end: range.index + range[0].length,
-          length: range[0].length - 1,
           type: match[1],
         }
       : false;

--- a/lib/api/behavior.test.js
+++ b/lib/api/behavior.test.js
@@ -507,7 +507,7 @@ describe("behavior", () => {
       ${"start only, or no marked text"}          | ${"a **test"}                | ${["BOLD", "ITALIC"]} | ${false}
       ${"start - end markers, or no marked text"} | ${"a **test**"}              | ${["BOLD", "ITALIC"]} | ${{ pattern: "**" }}
       ${"different start & end"}                  | ${"a **test*"}               | ${["BOLD", "ITALIC"]} | ${false}
-      ${"two marker sets"}                        | ${"a **test** two **test**"} | ${["BOLD"]}           | ${{}}
+      ${"two marker sets"}                        | ${"a __test__ two **test**"} | ${["BOLD"]}           | ${{ pattern: "**" }}
       ${"whitespace after start"}                 | ${"a** test**"}              | ${["BOLD"]}           | ${false}
     `("$label", ({ beforeInput, styles, expected }) => {
       const inlineStyles = styles.map((type) => ({ type }));

--- a/lib/api/behavior.test.js
+++ b/lib/api/behavior.test.js
@@ -515,7 +515,6 @@ describe("behavior", () => {
       ${"whitespace after open"}                   | ${"a _ test_"}             | ${["ITALIC"]}         | ${false}
       ${"whitespace before close"}                 | ${"a _test _"}             | ${["ITALIC"]}         | ${false}
     `("$label", ({ beforeInput, styles, expected }) => {
-      // TODO test _this_kind_of_pattern_
       const inlineStyles = styles.map((type) => ({ type }));
       const result = behavior.handleBeforeInputInlineStyle(
         beforeInput,

--- a/lib/api/behavior.test.js
+++ b/lib/api/behavior.test.js
@@ -496,20 +496,26 @@ describe("behavior", () => {
 
   describe("#handleBeforeInputInlineStyle", () => {
     it.each`
-      label                                       | beforeInput                | styles                | expected
-      ${"no marker"}                              | ${"test"}                  | ${["ITALIC"]}         | ${false}
-      ${"start only"}                             | ${"a _test"}               | ${["ITALIC"]}         | ${false}
-      ${"end only"}                               | ${"a test_"}               | ${["ITALIC"]}         | ${false}
-      ${"start - end markers"}                    | ${"a _test_"}              | ${["ITALIC"]}         | ${{}}
-      ${"start - end markers in the middle"}      | ${"a _test_ a"}            | ${["ITALIC"]}         | ${false}
-      ${"start - end markers whole text"}         | ${"_a test_"}              | ${["ITALIC"]}         | ${{}}
-      ${"no marked text"}                         | ${"a _test"}               | ${["ITALIC"]}         | ${false}
-      ${"start only, or no marked text"}          | ${"a _test"}               | ${["ITALIC", "BOLD"]} | ${false}
-      ${"start - end markers, or no marked text"} | ${"a _test_"}              | ${["ITALIC", "BOLD"]} | ${{ pattern: "_" }}
-      ${"different start & end"}                  | ${"a _test*"}              | ${["ITALIC", "BOLD"]} | ${false}
-      ${"two marker sets"}                        | ${"a __test__ two _test_"} | ${["ITALIC"]}         | ${{ pattern: "_" }}
-      ${"whitespace after start"}                 | ${"a_ test_"}              | ${["ITALIC"]}         | ${false}
+      label                                        | beforeInput                | styles                | expected
+      ${"no marker"}                               | ${"test"}                  | ${["ITALIC"]}         | ${false}
+      ${"open only"}                               | ${"a _test"}               | ${["ITALIC"]}         | ${false}
+      ${"close only"}                              | ${"a test_"}               | ${["ITALIC"]}         | ${false}
+      ${"open - close markers"}                    | ${"a _test_"}              | ${["ITALIC"]}         | ${{}}
+      ${"open - close markers in the middle"}      | ${"a _test_ a"}            | ${["ITALIC"]}         | ${false}
+      ${"open - close markers whole text"}         | ${"_a test_"}              | ${["ITALIC"]}         | ${{}}
+      ${"open - close markers single char"}        | ${"_a_"}                   | ${["ITALIC"]}         | ${{}}
+      ${"no marked text"}                          | ${"a _test"}               | ${["ITALIC"]}         | ${false}
+      ${"open only, or no marked text"}            | ${"a _test"}               | ${["ITALIC", "BOLD"]} | ${false}
+      ${"open - close markers, or no marked text"} | ${"a _test_"}              | ${["ITALIC", "BOLD"]} | ${{ pattern: "_" }}
+      ${"different open & close"}                  | ${"a _test*"}              | ${["ITALIC", "BOLD"]} | ${false}
+      ${"different open & close but similar"}      | ${"a __test_"}             | ${["ITALIC", "BOLD"]} | ${false}
+      ${"different open & close, after input"}     | ${"a _test__"}             | ${["ITALIC", "BOLD"]} | ${false}
+      ${"two marker sets"}                         | ${"a __test__ two _test_"} | ${["ITALIC", "BOLD"]} | ${{ pattern: "_" }}
+      ${"no whitespace before open"}               | ${"a_test_"}               | ${["ITALIC"]}         | ${false}
+      ${"whitespace after open"}                   | ${"a _ test_"}             | ${["ITALIC"]}         | ${false}
+      ${"whitespace before close"}                 | ${"a _test _"}             | ${["ITALIC"]}         | ${false}
     `("$label", ({ beforeInput, styles, expected }) => {
+      // TODO test _this_kind_of_pattern_
       const inlineStyles = styles.map((type) => ({ type }));
       const result = behavior.handleBeforeInputInlineStyle(
         beforeInput,
@@ -522,7 +528,7 @@ describe("behavior", () => {
       }
     });
 
-    it("start - end marker, handling", () => {
+    it("open - close marker, handling", () => {
       expect(
         behavior.handleBeforeInputInlineStyle("a **test**", [{ type: "BOLD" }]),
       ).toEqual({

--- a/lib/api/behavior.test.js
+++ b/lib/api/behavior.test.js
@@ -535,7 +535,6 @@ describe("behavior", () => {
         pattern: "**",
         start: 2,
         end: 10,
-        length: 8,
         type: "BOLD",
       });
     });

--- a/lib/api/behavior.test.js
+++ b/lib/api/behavior.test.js
@@ -494,6 +494,47 @@ describe("behavior", () => {
     });
   });
 
+  describe("#handleBeforeInputInlineStyle", () => {
+    it.each`
+      label                                       | beforeInput                  | styles                | expected
+      ${"no marker"}                              | ${"test"}                    | ${["BOLD"]}           | ${false}
+      ${"start only"}                             | ${"a **test"}                | ${["BOLD"]}           | ${false}
+      ${"end only"}                               | ${"a test**"}                | ${["BOLD"]}           | ${false}
+      ${"start - end markers"}                    | ${"a **test**"}              | ${["BOLD"]}           | ${{}}
+      ${"start - end markers in the middle"}      | ${"a **test** a"}            | ${["BOLD"]}           | ${false}
+      ${"start - end markers whole text"}         | ${"**a test**"}              | ${["BOLD"]}           | ${{}}
+      ${"no marked text"}                         | ${"a ****test"}              | ${["BOLD"]}           | ${false}
+      ${"start only, or no marked text"}          | ${"a **test"}                | ${["BOLD", "ITALIC"]} | ${false}
+      ${"start - end markers, or no marked text"} | ${"a **test**"}              | ${["BOLD", "ITALIC"]} | ${{ pattern: "**" }}
+      ${"different start & end"}                  | ${"a **test*"}               | ${["BOLD", "ITALIC"]} | ${false}
+      ${"two marker sets"}                        | ${"a **test** two **test**"} | ${["BOLD"]}           | ${{}}
+      ${"whitespace after start"}                 | ${"a** test**"}              | ${["BOLD"]}           | ${false}
+    `("$label", ({ beforeInput, styles, expected }) => {
+      const inlineStyles = styles.map((type) => ({ type }));
+      const result = behavior.handleBeforeInputInlineStyle(
+        beforeInput,
+        inlineStyles,
+      );
+      if (expected) {
+        expect(result).toMatchObject(expected);
+      } else {
+        expect(result).toEqual(expected);
+      }
+    });
+
+    it("start - end marker, handling", () => {
+      expect(
+        behavior.handleBeforeInputInlineStyle("a **test**", [{ type: "BOLD" }]),
+      ).toEqual({
+        pattern: "**",
+        start: 2,
+        end: 10,
+        length: 8,
+        type: "BOLD",
+      });
+    });
+  });
+
   describe("#getCustomStyleMap", () => {
     it("existing styles, default styling", () => {
       expect(

--- a/lib/api/behavior.test.js
+++ b/lib/api/behavior.test.js
@@ -496,19 +496,19 @@ describe("behavior", () => {
 
   describe("#handleBeforeInputInlineStyle", () => {
     it.each`
-      label                                       | beforeInput                  | styles                | expected
-      ${"no marker"}                              | ${"test"}                    | ${["BOLD"]}           | ${false}
-      ${"start only"}                             | ${"a **test"}                | ${["BOLD"]}           | ${false}
-      ${"end only"}                               | ${"a test**"}                | ${["BOLD"]}           | ${false}
-      ${"start - end markers"}                    | ${"a **test**"}              | ${["BOLD"]}           | ${{}}
-      ${"start - end markers in the middle"}      | ${"a **test** a"}            | ${["BOLD"]}           | ${false}
-      ${"start - end markers whole text"}         | ${"**a test**"}              | ${["BOLD"]}           | ${{}}
-      ${"no marked text"}                         | ${"a ****test"}              | ${["BOLD"]}           | ${false}
-      ${"start only, or no marked text"}          | ${"a **test"}                | ${["BOLD", "ITALIC"]} | ${false}
-      ${"start - end markers, or no marked text"} | ${"a **test**"}              | ${["BOLD", "ITALIC"]} | ${{ pattern: "**" }}
-      ${"different start & end"}                  | ${"a **test*"}               | ${["BOLD", "ITALIC"]} | ${false}
-      ${"two marker sets"}                        | ${"a __test__ two **test**"} | ${["BOLD"]}           | ${{ pattern: "**" }}
-      ${"whitespace after start"}                 | ${"a** test**"}              | ${["BOLD"]}           | ${false}
+      label                                       | beforeInput                | styles                | expected
+      ${"no marker"}                              | ${"test"}                  | ${["ITALIC"]}         | ${false}
+      ${"start only"}                             | ${"a _test"}               | ${["ITALIC"]}         | ${false}
+      ${"end only"}                               | ${"a test_"}               | ${["ITALIC"]}         | ${false}
+      ${"start - end markers"}                    | ${"a _test_"}              | ${["ITALIC"]}         | ${{}}
+      ${"start - end markers in the middle"}      | ${"a _test_ a"}            | ${["ITALIC"]}         | ${false}
+      ${"start - end markers whole text"}         | ${"_a test_"}              | ${["ITALIC"]}         | ${{}}
+      ${"no marked text"}                         | ${"a _test"}               | ${["ITALIC"]}         | ${false}
+      ${"start only, or no marked text"}          | ${"a _test"}               | ${["ITALIC", "BOLD"]} | ${false}
+      ${"start - end markers, or no marked text"} | ${"a _test_"}              | ${["ITALIC", "BOLD"]} | ${{ pattern: "_" }}
+      ${"different start & end"}                  | ${"a _test*"}              | ${["ITALIC", "BOLD"]} | ${false}
+      ${"two marker sets"}                        | ${"a __test__ two _test_"} | ${["ITALIC"]}         | ${{ pattern: "_" }}
+      ${"whitespace after start"}                 | ${"a_ test_"}              | ${["ITALIC"]}         | ${false}
     `("$label", ({ beforeInput, styles, expected }) => {
       const inlineStyles = styles.map((type) => ({ type }));
       const result = behavior.handleBeforeInputInlineStyle(

--- a/lib/api/constants.js
+++ b/lib/api/constants.js
@@ -156,14 +156,30 @@ export const INPUT_BLOCK_MAP = {
 
 export const INPUT_STYLE_MAP = [
   // Order matters, as shorter patterns are contained in the longer ones.
-  ["**", INLINE_STYLE.BOLD],
-  ["__", INLINE_STYLE.BOLD],
-  ["*", INLINE_STYLE.ITALIC],
-  ["_", INLINE_STYLE.ITALIC],
-  ["~~", INLINE_STYLE.STRIKETHROUGH],
-  ["~", INLINE_STYLE.STRIKETHROUGH],
-  ["`", INLINE_STYLE.CODE],
-];
+  { pattern: "**", type: INLINE_STYLE.BOLD },
+  { pattern: "__", type: INLINE_STYLE.BOLD },
+  { pattern: "*", type: INLINE_STYLE.ITALIC },
+  { pattern: "_", type: INLINE_STYLE.ITALIC },
+  { pattern: "~~", type: INLINE_STYLE.STRIKETHROUGH },
+  { pattern: "~", type: INLINE_STYLE.STRIKETHROUGH },
+  { pattern: "`", type: INLINE_STYLE.CODE },
+].map<{|
+  pattern: string,
+  type: string,
+  regex: string,
+|}>(({ pattern, type }) => {
+  const pat = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const char = pattern[0].replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // https://regexper.com/#%28%5Cs%7C%5E%29__%28%5B%5E%5Cs_%5D%7B1%2C2%7D%7C%5B%5E%5Cs_%5D.%2B%5B%5E%5Cs_%5D%29__%24
+  // This is stored as an escaped string instead of a RegExp object because they are stateful.
+  const regex = `(\\s|^)${pat}([^\\s${char}]{1,2}|[^\\s${char}].+[^\\s${char}])${pat}$`;
+
+  return {
+    pattern,
+    type,
+    regex,
+  };
+});
 
 export const INPUT_ENTITY_MAP = {};
 

--- a/lib/api/constants.js
+++ b/lib/api/constants.js
@@ -172,6 +172,11 @@ export const INPUT_STYLE_MAP = [
   const char = pattern[0].replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   // https://regexper.com/#%28%5Cs%7C%5E%29__%28%5B%5E%5Cs_%5D%7B1%2C2%7D%7C%5B%5E%5Cs_%5D.%2B%5B%5E%5Cs_%5D%29__%24
   // This is stored as an escaped string instead of a RegExp object because they are stateful.
+  // This regex encapsulates a few rules:
+  // - The pattern must be preceded by whitespace, or be at the start of the input.
+  // - The pattern must end the input.
+  // - In-between the start and end patterns, there can't be only whitespace or characters from the pattern.
+  // - There has to be at least 1 char that's not whitespace or the pattern’s char.
   const regex = `(\\s|^)${pat}([^\\s${char}]{1,2}|[^\\s${char}].+[^\\s${char}])${pat}$`;
 
   return {

--- a/lib/api/constants.js
+++ b/lib/api/constants.js
@@ -154,16 +154,16 @@ export const INPUT_BLOCK_MAP = {
   "```": BLOCK_TYPE.CODE,
 };
 
-export const INPUT_STYLE_MAP = {
+export const INPUT_STYLE_MAP = [
   // Order matters, as shorter patterns are contained in the longer ones.
-  "**": INLINE_STYLE.BOLD,
-  __: INLINE_STYLE.BOLD,
-  "*": INLINE_STYLE.ITALIC,
-  _: INLINE_STYLE.ITALIC,
-  "~~": INLINE_STYLE.STRIKETHROUGH,
-  "~": INLINE_STYLE.STRIKETHROUGH,
-  "`": INLINE_STYLE.CODE,
-};
+  ["**", INLINE_STYLE.BOLD],
+  ["__", INLINE_STYLE.BOLD],
+  ["*", INLINE_STYLE.ITALIC],
+  ["_", INLINE_STYLE.ITALIC],
+  ["~~", INLINE_STYLE.STRIKETHROUGH],
+  ["~", INLINE_STYLE.STRIKETHROUGH],
+  ["`", INLINE_STYLE.CODE],
+];
 
 export const INPUT_ENTITY_MAP = {};
 

--- a/lib/api/constants.js
+++ b/lib/api/constants.js
@@ -154,6 +154,17 @@ export const INPUT_BLOCK_MAP = {
   "```": BLOCK_TYPE.CODE,
 };
 
+export const INPUT_STYLE_MAP = {
+  // Order matters, as shorter patterns are contained in the longer ones.
+  "**": INLINE_STYLE.BOLD,
+  __: INLINE_STYLE.BOLD,
+  "*": INLINE_STYLE.ITALIC,
+  _: INLINE_STYLE.ITALIC,
+  "~~": INLINE_STYLE.STRIKETHROUGH,
+  "~": INLINE_STYLE.STRIKETHROUGH,
+  "`": INLINE_STYLE.CODE,
+};
+
 export const INPUT_ENTITY_MAP = {};
 
 INPUT_ENTITY_MAP[ENTITY_TYPE.HORIZONTAL_RULE] = "---";

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -608,40 +608,11 @@ class DraftailEditor extends Component<Props, State> {
       );
 
       if (newStyle) {
-        let newContent = newEditorState.getCurrentContent();
-
-        let target = selection.merge({
-          anchorOffset: newStyle.start,
-          focusOffset: newStyle.end,
-        });
-        newContent = Modifier.replaceText(
-          newContent,
-          target,
-          text
-            .slice(newStyle.start, newStyle.end)
-            .replace(newStyle.pattern, "")
-            .replace(newStyle.pattern, "") + char,
-        );
-        target = target.merge({
-          focusOffset: newStyle.end - newStyle.pattern.length * 2,
-        });
-        newContent = Modifier.applyInlineStyle(
-          newContent,
-          target,
-          newStyle.type,
-        );
-
-        const endSelection = target.merge({
-          anchorOffset: target.getFocusOffset() + 1,
-          focusOffset: target.getFocusOffset() + 1,
-        });
-        newContent = newContent.merge({
-          selectionAfter: endSelection,
-        });
-        newEditorState = EditorState.push(
+        newEditorState = DraftUtils.applyMarkdownStyle(
           newEditorState,
-          newContent,
-          "change-inline-style",
+          newStyle,
+          text,
+          char,
         );
       }
 

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -611,7 +611,6 @@ class DraftailEditor extends Component<Props, State> {
         newEditorState = DraftUtils.applyMarkdownStyle(
           newEditorState,
           newStyle,
-          text,
           char,
         );
       }

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -490,9 +490,8 @@ class DraftailEditor extends Component<Props, State> {
 
   /* :: handleReturn: (e: SyntheticKeyboardEvent<>) => 'not-handled' | 'handled'; */
   handleReturn(e: SyntheticKeyboardEvent<>) {
-    const { enableLineBreak } = this.props;
+    const { enableLineBreak, inlineStyles } = this.props;
     const { editorState } = this.state;
-    const contentState = editorState.getCurrentContent();
     let ret = NOT_HANDLED;
 
     // alt + enter opens links and other entities with a `url` property.
@@ -504,7 +503,8 @@ class DraftailEditor extends Component<Props, State> {
       const entityKey = DraftUtils.getSelectionEntity(editorState);
 
       if (entityKey) {
-        const entityData = contentState.getEntity(entityKey).getData();
+        const content = editorState.getCurrentContent();
+        const entityData = content.getEntity(entityKey).getData();
 
         if (entityData.url) {
           window.open(entityData.url);
@@ -518,7 +518,34 @@ class DraftailEditor extends Component<Props, State> {
 
       let newState = editorState;
 
-      newState = DraftUtils.handleNewLine(newState, e);
+      const selection = newState.getSelection();
+      // Check whether we should apply a Markdown styles shortcut.
+      if (selection.isCollapsed()) {
+        const block = DraftUtils.getSelectedBlock(editorState);
+        const newStyle = behavior.handleBeforeInputInlineStyle(
+          block.getText(),
+          inlineStyles,
+        );
+
+        if (newStyle) {
+          newState = DraftUtils.applyMarkdownStyle(newState, newStyle, "");
+        }
+
+        const newLineState = DraftUtils.handleNewLine(newState, e);
+
+        // Manually handle the return if there is a style to apply.
+        if (!newLineState && newStyle) {
+          const content = newState.getCurrentContent();
+          const newContent = Modifier.splitBlock(content, selection);
+          newState = EditorState.push(newState, newContent, "split-block");
+          // Do not propagate the style from the last block.
+          newState = RichUtils.toggleInlineStyle(newState, newStyle.type);
+        } else {
+          newState = newLineState;
+        }
+      } else {
+        newState = DraftUtils.handleNewLine(newState, e);
+      }
 
       if (newState && newState !== editorState) {
         ret = HANDLED;
@@ -601,7 +628,6 @@ class DraftailEditor extends Component<Props, State> {
         );
       }
 
-      // TODO Do it on return as well.
       const newStyle = behavior.handleBeforeInputInlineStyle(
         beforeInput,
         inlineStyles,

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -517,12 +517,13 @@ class DraftailEditor extends Component<Props, State> {
       }
 
       let newState = editorState;
+      let newStyle = false;
 
       const selection = newState.getSelection();
       // Check whether we should apply a Markdown styles shortcut.
       if (selection.isCollapsed()) {
         const block = DraftUtils.getSelectedBlock(editorState);
-        const newStyle = behavior.handleBeforeInputInlineStyle(
+        newStyle = behavior.handleBeforeInputInlineStyle(
           block.getText(),
           inlineStyles,
         );
@@ -530,21 +531,19 @@ class DraftailEditor extends Component<Props, State> {
         if (newStyle) {
           newState = DraftUtils.applyMarkdownStyle(newState, newStyle, "");
         }
+      }
 
-        const newLineState = DraftUtils.handleNewLine(newState, e);
+      const newLineState = DraftUtils.handleNewLine(newState, e);
 
-        // Manually handle the return if there is a style to apply.
-        if (!newLineState && newStyle) {
-          const content = newState.getCurrentContent();
-          const newContent = Modifier.splitBlock(content, selection);
-          newState = EditorState.push(newState, newContent, "split-block");
-          // Do not propagate the style from the last block.
-          newState = RichUtils.toggleInlineStyle(newState, newStyle.type);
-        } else {
-          newState = newLineState;
-        }
+      // Manually handle the return if there is a style to apply.
+      if (!newLineState && newStyle) {
+        const content = newState.getCurrentContent();
+        const newContent = Modifier.splitBlock(content, selection);
+        newState = EditorState.push(newState, newContent, "split-block");
+        // Do not propagate the style from the last block.
+        newState = RichUtils.toggleInlineStyle(newState, newStyle.type);
       } else {
-        newState = DraftUtils.handleNewLine(newState, e);
+        newState = newLineState;
       }
 
       if (newState && newState !== editorState) {

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from "react";
 import type { ComponentType } from "react";
-import { EditorState, RichUtils, ContentBlock } from "draft-js";
+import { EditorState, RichUtils, ContentBlock, Modifier } from "draft-js";
 import type { EntityInstance } from "draft-js";
 import type { RawDraftContentState } from "draft-js/lib/RawDraftContentState";
 import type { DraftEditorCommand } from "draft-js/lib/DraftEditorCommand";
@@ -516,9 +516,11 @@ class DraftailEditor extends Component<Props, State> {
         e.which = 0;
       }
 
-      const newState = DraftUtils.handleNewLine(editorState, e);
+      let newState = editorState;
 
-      if (newState) {
+      newState = DraftUtils.handleNewLine(newState, e);
+
+      if (newState && newState !== editorState) {
         ret = HANDLED;
         this.onChange(newState);
       }
@@ -567,7 +569,7 @@ class DraftailEditor extends Component<Props, State> {
 
   /* :: handleBeforeInput: (char: string) => 'handled' | 'not-handled'; */
   handleBeforeInput(char: string) {
-    const { blockTypes, enableHorizontalRule } = this.props;
+    const { blockTypes, inlineStyles, enableHorizontalRule } = this.props;
     const { editorState } = this.state;
     const selection = editorState.getSelection();
 
@@ -575,8 +577,8 @@ class DraftailEditor extends Component<Props, State> {
       const block = DraftUtils.getSelectedBlock(editorState);
       const startOffset = selection.getStartOffset();
       const text = block.getText();
-      const beforeBeforeInput = text.slice(0, startOffset);
-      const mark = `${beforeBeforeInput}${char}`;
+      const beforeInput = text.slice(0, startOffset);
+      const mark = `${beforeInput}${char}`;
       let newEditorState = editorState;
 
       const newBlockType = behavior.handleBeforeInputBlockType(
@@ -588,7 +590,7 @@ class DraftailEditor extends Component<Props, State> {
         newEditorState = DraftUtils.resetBlockWithType(
           newEditorState,
           newBlockType,
-          text.replace(beforeBeforeInput, ""),
+          text.replace(beforeInput, ""),
         );
       }
 
@@ -596,6 +598,50 @@ class DraftailEditor extends Component<Props, State> {
         newEditorState = DraftUtils.removeBlock(
           DraftUtils.addHorizontalRuleRemovingSelection(newEditorState),
           block.getKey(),
+        );
+      }
+
+      // TODO Do it on return as well.
+      const newStyle = behavior.handleBeforeInputInlineStyle(
+        beforeInput,
+        inlineStyles,
+      );
+
+      if (newStyle) {
+        let newContent = newEditorState.getCurrentContent();
+
+        let target = selection.merge({
+          anchorOffset: newStyle.start,
+          focusOffset: newStyle.end,
+        });
+        newContent = Modifier.replaceText(
+          newContent,
+          target,
+          text
+            .slice(newStyle.start, newStyle.end)
+            .replace(newStyle.pattern, "")
+            .replace(newStyle.pattern, "") + char,
+        );
+        target = target.merge({
+          focusOffset: newStyle.end - newStyle.pattern.length * 2,
+        });
+        newContent = Modifier.applyInlineStyle(
+          newContent,
+          target,
+          newStyle.type,
+        );
+
+        const endSelection = target.merge({
+          anchorOffset: target.getFocusOffset() + 1,
+          focusOffset: target.getFocusOffset() + 1,
+        });
+        newContent = newContent.merge({
+          selectionAfter: endSelection,
+        });
+        newEditorState = EditorState.push(
+          newEditorState,
+          newContent,
+          "change-inline-style",
         );
       }
 

--- a/lib/components/DraftailEditor.test.js
+++ b/lib/components/DraftailEditor.test.js
@@ -15,7 +15,7 @@ import DraftUtils from "../api/DraftUtils";
 import DividerBlock from "../blocks/DividerBlock";
 import DraftailEditor from "./DraftailEditor";
 import Toolbar from "./Toolbar";
-import { ENTITY_TYPE } from "../api/constants";
+import { ENTITY_TYPE, INLINE_STYLE } from "../api/constants";
 
 jest.mock("draft-js/lib/generateRandomKey", () => () => "a");
 
@@ -401,7 +401,7 @@ describe("DraftailEditor", () => {
     it("default", () => {
       jest
         .spyOn(DraftUtils, "handleNewLine")
-        .mockImplementation((editorState) => editorState);
+        .mockImplementation(() => EditorState.createEmpty());
       const wrapper = shallowNoLifecycle(<DraftailEditor />);
 
       expect(
@@ -412,6 +412,7 @@ describe("DraftailEditor", () => {
 
       DraftUtils.handleNewLine.mockRestore();
     });
+
     it("enabled br", () => {
       const wrapper = shallowNoLifecycle(<DraftailEditor enableLineBreak />);
 
@@ -421,6 +422,7 @@ describe("DraftailEditor", () => {
         }),
       ).toBe("not-handled");
     });
+
     it("alt + enter on text", () => {
       const wrapper = shallowNoLifecycle(<DraftailEditor />);
 
@@ -430,6 +432,7 @@ describe("DraftailEditor", () => {
         }),
       ).toBe("handled");
     });
+
     it("alt + enter on entity without url", () => {
       const wrapper = shallowNoLifecycle(
         <DraftailEditor
@@ -437,24 +440,17 @@ describe("DraftailEditor", () => {
             entityMap: {
               "1": {
                 type: "LINK",
-                mutability: "IMMUTABLE",
                 data: {
                   url: "test",
                 },
               },
               "2": {
                 type: "LINK",
-                mutability: "IMMUTABLE",
-                data: {},
               },
             },
             blocks: [
               {
-                key: "b3kdk",
                 text: "test",
-                type: "unstyled",
-                depth: 0,
-                inlineStyleRanges: [],
                 entityRanges: [
                   {
                     offset: 0,
@@ -462,7 +458,6 @@ describe("DraftailEditor", () => {
                     key: 2,
                   },
                 ],
-                data: {},
               },
             ],
           }}
@@ -484,7 +479,6 @@ describe("DraftailEditor", () => {
             entityMap: {
               "1": {
                 type: "LINK",
-                mutability: "IMMUTABLE",
                 data: {
                   url: "test",
                 },
@@ -492,11 +486,7 @@ describe("DraftailEditor", () => {
             },
             blocks: [
               {
-                key: "b3kdk",
                 text: "test",
-                type: "unstyled",
-                depth: 0,
-                inlineStyleRanges: [],
                 entityRanges: [
                   {
                     offset: 0,
@@ -504,7 +494,6 @@ describe("DraftailEditor", () => {
                     key: 1,
                   },
                 ],
-                data: {},
               },
             ],
           }}
@@ -519,6 +508,54 @@ describe("DraftailEditor", () => {
       expect(window.open).toHaveBeenCalled();
 
       window.open.mockRestore();
+    });
+
+    it("style shortcut", () => {
+      jest.spyOn(DraftUtils, "applyMarkdownStyle");
+
+      const wrapper = shallowNoLifecycle(
+        <DraftailEditor
+          rawContentState={{
+            entityMap: {},
+            blocks: [{ text: "A *test*" }],
+          }}
+          inlineStyles={[{ type: INLINE_STYLE.ITALIC }]}
+        />,
+      );
+
+      expect(wrapper.instance().handleReturn({})).toBe("handled");
+      expect(DraftUtils.applyMarkdownStyle).toHaveBeenCalled();
+
+      DraftUtils.applyMarkdownStyle.mockRestore();
+    });
+
+    it("style shortcut but selection is not collapsed", () => {
+      jest.spyOn(DraftUtils, "applyMarkdownStyle");
+
+      const wrapper = shallowNoLifecycle(
+        <DraftailEditor
+          rawContentState={{
+            entityMap: {},
+            blocks: [{ key: "aaaa2", text: "A *test*" }],
+          }}
+          inlineStyles={[{ type: INLINE_STYLE.ITALIC }]}
+        />,
+      );
+
+      // Monkey-patching the one method. A bit dirty.
+      const selection = new SelectionState().set("anchorKey", "aaaa2");
+      selection.isCollapsed = () => false;
+      wrapper.setState({
+        editorState: Object.assign(wrapper.state("editorState"), {
+          getSelection: () => selection,
+          getCurrentInlineStyle: () => new OrderedSet(),
+        }),
+      });
+
+      expect(wrapper.instance().handleReturn({})).toBe("not-handled");
+      expect(DraftUtils.applyMarkdownStyle).not.toHaveBeenCalled();
+
+      DraftUtils.applyMarkdownStyle.mockRestore();
     });
   });
 
@@ -680,8 +717,10 @@ describe("DraftailEditor", () => {
         .spyOn(DraftUtils, "getSelectedBlock")
         .mockImplementation(() => new ContentBlock());
       jest.spyOn(DraftUtils, "addHorizontalRuleRemovingSelection");
+      jest.spyOn(DraftUtils, "applyMarkdownStyle");
       jest.spyOn(behavior, "handleBeforeInputBlockType");
       jest.spyOn(behavior, "handleBeforeInputHR");
+      jest.spyOn(behavior, "handleBeforeInputInlineStyle");
 
       jest.spyOn(wrapper.instance(), "onChange");
     });
@@ -729,6 +768,19 @@ describe("DraftailEditor", () => {
       expect(wrapper.instance().onChange).toHaveBeenCalled();
       expect(DraftUtils.addHorizontalRuleRemovingSelection).toHaveBeenCalled();
       DraftUtils.shouldHidePlaceholder.mockRestore();
+    });
+
+    it("change style", () => {
+      wrapper.instance().render = () => {};
+      behavior.handleBeforeInputInlineStyle = jest.fn(() => ({
+        pattern: "**",
+        type: "BOLD",
+        start: 0,
+        end: 0,
+      }));
+      expect(wrapper.instance().handleBeforeInput("!")).toBe("handled");
+      expect(wrapper.instance().onChange).toHaveBeenCalled();
+      expect(DraftUtils.applyMarkdownStyle).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Addresses #134.

The implementation intends to make it possible to use the Markdown formatting (e.g. `**`) as shortcuts when entering content, while still allowing this same formatting to be present in the text otherwise. Formatting should only be replaced (treated as an input shortcut) when the cursor is right next to it, among other criteria.