### PR TITLE
Clear save timeout handler when unmounting the editor. Fix #208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - Fix empty buttons appearing when providing custom formats without a defined label or icon. [#442](https://github.com/springload/draftail/pull/442)
+- Clear save timeout handler when unmounting the editor. [#208](https://github.com/springload/draftail/issues/208), [#443](https://github.com/springload/draftail/pull/443)
 
 ## [[v1.3.0]](https://github.com/springload/draftail/releases/tag/v1.3.0)
 

--- a/lib/components/DraftailEditor.js
+++ b/lib/components/DraftailEditor.js
@@ -329,6 +329,8 @@ class DraftailEditor extends Component<Props, State> {
 
   componentWillUnmount() {
     this.copySource.unregister();
+
+    window.clearTimeout(this.updateTimeout);
   }
 
   /* :: onFocus: () => void; */

--- a/lib/components/DraftailEditor.test.js
+++ b/lib/components/DraftailEditor.test.js
@@ -359,9 +359,11 @@ describe("DraftailEditor", () => {
     const wrapper = mount(<DraftailEditor />);
     const { copySource } = wrapper.instance();
     jest.spyOn(copySource, "unregister");
+    jest.spyOn(window, "clearTimeout");
     expect(copySource).not.toBeNull();
     wrapper.unmount();
     expect(copySource.unregister).toHaveBeenCalled();
+    expect(window.clearTimeout).toHaveBeenCalled();
   });
 
   describe("onChange", () => {


### PR DESCRIPTION
Fixes #208. This is very easily spotted in Storybook by rapidly moving between different stories.

---

<!-- Here are guidelines to follow when creating your pull request: -->

- [x] Stay on point and keep it small so it can be easily reviewed. For example, try to apply any general refactoring separately outside of the PR.
- [x] Consider adding unit tests, especially for bug fixes. If you don't, tell us why.
- [x] All new and existing tests pass, with 100% test coverage (`npm run test:coverage`)
- [x] Linting passes (`npm run lint`)
- ~[ ] Consider updating documentation. If you don't, tell us why.~ Not relevant
- [x] List the environments / platforms in which you tested your changes. Chrome and Safari on macOS

Thanks for contributing to Draftail!
