### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 > Documentation: [draftail.org/docs/next/getting-started](https://www.draftail.org/docs/next/getting-started)
 
+## [[v1.4.0]](https://github.com/springload/draftail/releases/tag/v1.4.0)
+
+> Documentation: [draftail.org/docs/getting-started](https://www.draftail.org/docs/getting-started)
+
 ### Added
 
 - Make it possible to hide buttons with default labels by setting their `label` to `null`. [#442](https://github.com/springload/draftail/pull/442)
@@ -21,7 +25,7 @@
 
 ## [[v1.3.0]](https://github.com/springload/draftail/releases/tag/v1.3.0)
 
-> Documentation: [draftail.org/docs/getting-started](https://www.draftail.org/docs/getting-started)
+> Documentation: [draftail.org/docs/1.3.0/getting-started](https://www.draftail.org/docs/1.3.0/getting-started)
 
 🎉 blog post for this release: [Draftail v1.3.0: community improvements, beyond Wagtail](https://www.draftail.org/blog/2019/03/03/draftail-v1-2-0-supporting-modern-experiences).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "draftail",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draftail",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "📝🍸 A configurable rich text editor built with Draft.js",
   "author": "Springload",
   "license": "MIT",


### PR DESCRIPTION
> Documentation: [draftail.org/docs/getting-started](https://www.draftail.org/docs/getting-started)

### Added

- Make it possible to hide buttons with default labels by setting their `label` to `null`. [#442](https://github.com/springload/draftail/pull/442)

### Changed

- Improve the editor props’ JSDoc annotations. [#441](https://github.com/springload/draftail/pull/441)

### Fixed

- Fix empty buttons appearing when providing custom formats without a defined label or icon. [#442](https://github.com/springload/draftail/pull/442)
- Clear save timeout handler when unmounting the editor. [#208](https://github.com/springload/draftail/issues/208), [#443](https://github.com/springload/draftail/pull/443)