### PR TITLE
Fix missing HR in command palette

### DIFF
--- a/src/api/behavior.ts
+++ b/src/api/behavior.ts
@@ -367,6 +367,16 @@ export default {
             ...t,
             category: "entityTypes",
           }));
+
+        if (enableHorizontalRule) {
+          items.push({
+            type: ENTITY_TYPE.HORIZONTAL_RULE,
+            ...(typeof enableHorizontalRule === "object"
+              ? enableHorizontalRule
+              : {}),
+            category: "entityTypes",
+          });
+        }
       }
 
       return {


### PR DESCRIPTION
When the command palette is built without a prescribed list of commands, the horizontal rule is added to the list of entity types, if it is configured via `enableHorizontalRule`. If the command palette is built by passing a list of commands, though, `enableHorizontalRule` is ignored and the HR is not added to the list of entity types.

This seems inadvertent and causes the HR to get dropped even if it has been configured. This seems to be the cause of https://github.com/wagtail/wagtail/issues/9707, unless I am misunderstanding how this code is supposed to work.

The fix in Wagtail's bakerydemo:

|Before|After|
|-|-|
|<img width="409" alt="image" src="https://user-images.githubusercontent.com/654645/220693745-77eecd38-8039-42b1-b9d2-cef344aa49e1.png">|<img width="418" alt="image" src="https://user-images.githubusercontent.com/654645/220691921-9f116a53-c19c-457c-8df0-3444d54f0cee.png">|

(Note: there is likely a DRYer way to implement this without repeating code from above, but my TypeScript skills are pretty basic. Any better suggestions would be appreciated!)